### PR TITLE
perf: add click fast path

### DIFF
--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -48,7 +48,7 @@ try {
 | `INVALID_ARGUMENT` | Caller passed an invalid value (bad enum, wrong shape, unparseable duration…). | Read the message; it lists the accepted forms. |
 | `UNSUPPORTED` | Feature exists but is unavailable on this browser/transport (e.g. Chromium-only over Firefox, or a BiDi-only feature with BiDi disabled). | Enable BiDi (`enableBiDi: true`) or switch browser. |
 | `STATE_INVALID` | Method called in the wrong state (e.g. `stopTrace()` without `startTrace()`). | Call the prerequisite first. |
-| `DRIVER_ERROR` | Driver-level / transport-level failure surfaced to the caller. | Inspect `error.cause`. |
+| `DRIVER_ERROR` | A WebDriver command returned a protocol error (non-200 response) — e.g. `stale element reference`, `element click intercepted`, `invalid selector` — or a transport-level failure. | `error.detail.webDriverError` carries the W3C JSON error code and `error.detail.webDriverMessage` the driver's message; recovery loops match on `webDriverError`. Also inspect `error.cause`. |
 
 ## Stability
 

--- a/src/cli/mcp/server.ts
+++ b/src/cli/mcp/server.ts
@@ -223,7 +223,7 @@ async function callTool(
     value = await runTool(ctx, tool, args);
   } catch (e) {
     if (e instanceof CraftdriverError) {
-      return toolError(e.message, e.code, e.hint);
+      return toolError(e.message, e.code, e.hint, compactErrorDetail(e.detail));
     }
     return toolError((e as Error).message ?? String(e), ErrorCode.DRIVER_ERROR);
   }
@@ -297,13 +297,31 @@ function safeJson(value: unknown): string {
   }
 }
 
-function toolError(message: string, code: string, hint?: string): ToolCallResult {
+function compactErrorDetail(detail?: Record<string, unknown>): Record<string, unknown> | undefined {
+  if (!detail) return undefined;
+  const compact = { ...detail };
+  delete compact.stacktrace;
+  return Object.keys(compact).length > 0 ? compact : undefined;
+}
+
+function toolError(
+  message: string,
+  code: string,
+  hint?: string,
+  detail?: Record<string, unknown>
+): ToolCallResult {
   const lines = [`error: ${message}`, `code:  ${code}`];
   if (hint) lines.push(`hint:  ${hint}`);
+  const error = {
+    code,
+    message,
+    ...(hint ? { hint } : {}),
+    ...(detail ? { detail } : {}),
+  };
   return {
     isError: true,
     content: [{ type: 'text', text: lines.join('\n') }],
-    structuredContent: { error: { code, message, hint } },
+    structuredContent: { error },
   };
 }
 

--- a/src/lib/browser.ts
+++ b/src/lib/browser.ts
@@ -47,6 +47,7 @@ import { Tracer, type TraceStartOptions } from './tracing.js';
 import { A11y } from './a11y.js';
 import { Clock } from './clock.js';
 import { CraftdriverError, ErrorCode } from './errors.js';
+import { clickWithFastPath } from './clickFastPath.js';
 
 /** Device metrics for custom mobile emulation */
 export interface DeviceMetrics {
@@ -309,20 +310,6 @@ function selectorToString(sel: string | By | undefined): string | undefined {
   } catch {
     return undefined;
   }
-}
-
-const RECOVERABLE_FAST_CLICK_ERRORS: ReadonlySet<string> = new Set([
-  'no such element',
-  'stale element reference',
-  'element not interactable',
-  'element click intercepted',
-  'move target out of bounds',
-]);
-
-function isRecoverableFastClickError(err: unknown): boolean {
-  if (!CraftdriverError.is(err, ErrorCode.DRIVER_ERROR)) return false;
-  const code = err.detail?.webDriverError;
-  return typeof code === 'string' && RECOVERABLE_FAST_CLICK_ERRORS.has(code);
 }
 
 /** Recursively find the child context that matches an iframe's src URL. */
@@ -2120,19 +2107,11 @@ export class Browser {
     if (this._tracer?.isRunning) this._tracer.recordAction('click', undefined, selectorToString(selector));
     const by = typeof selector === 'string' ? By.css(selector) : selector;
     const timeout = opts?.timeout ?? this.defaults.timeout;
-    const deadline = Date.now() + timeout;
-
-    try {
-      const el = await this.driver.findElement(by);
-      await el.click();
-      return;
-    } catch (err) {
-      if (!isRecoverableFastClickError(err)) throw err;
-      const remaining = Math.max(0, deadline - Date.now());
-      if (remaining <= 0) throw err;
-      const el = await this.driver.wait(until.elementIsVisible(by), { timeout: remaining });
-      await el.click();
-    }
+    await clickWithFastPath(
+      () => this.driver.findElement(by),
+      (remaining) => this.driver.wait(until.elementIsVisible(by), { timeout: remaining }),
+      timeout
+    );
   }
 
   async fill(

--- a/src/lib/browser.ts
+++ b/src/lib/browser.ts
@@ -311,6 +311,20 @@ function selectorToString(sel: string | By | undefined): string | undefined {
   }
 }
 
+const RECOVERABLE_FAST_CLICK_ERRORS: ReadonlySet<string> = new Set([
+  'no such element',
+  'stale element reference',
+  'element not interactable',
+  'element click intercepted',
+  'move target out of bounds',
+]);
+
+function isRecoverableFastClickError(err: unknown): boolean {
+  if (!CraftdriverError.is(err, ErrorCode.DRIVER_ERROR)) return false;
+  const code = err.detail?.webDriverError;
+  return typeof code === 'string' && RECOVERABLE_FAST_CLICK_ERRORS.has(code);
+}
+
 /** Recursively find the child context that matches an iframe's src URL. */
 function findIframeContext(
   ctx: BidiContextInfo,
@@ -2105,8 +2119,20 @@ export class Browser {
   async click(selector: string | By, opts?: { timeout?: number }): Promise<void> {
     if (this._tracer?.isRunning) this._tracer.recordAction('click', undefined, selectorToString(selector));
     const by = typeof selector === 'string' ? By.css(selector) : selector;
-    const el = await this.driver.wait(until.elementIsVisible(by), { timeout: opts?.timeout ?? this.defaults.timeout });
-    await el.click();
+    const timeout = opts?.timeout ?? this.defaults.timeout;
+    const deadline = Date.now() + timeout;
+
+    try {
+      const el = await this.driver.findElement(by);
+      await el.click();
+      return;
+    } catch (err) {
+      if (!isRecoverableFastClickError(err)) throw err;
+      const remaining = Math.max(0, deadline - Date.now());
+      if (remaining <= 0) throw err;
+      const el = await this.driver.wait(until.elementIsVisible(by), { timeout: remaining });
+      await el.click();
+    }
   }
 
   async fill(

--- a/src/lib/clickFastPath.ts
+++ b/src/lib/clickFastPath.ts
@@ -1,0 +1,44 @@
+import { CraftdriverError, ErrorCode } from './errors.js';
+import type { WebElement } from './webelement.js';
+
+const RECOVERABLE_CLICK_ERRORS: ReadonlySet<string> = new Set([
+  'no such element',
+  'stale element reference',
+  'element not interactable',
+  'element click intercepted',
+  'move target out of bounds',
+]);
+
+function isRecoverableClickError(err: unknown): boolean {
+  if (!CraftdriverError.is(err, ErrorCode.DRIVER_ERROR)) return false;
+  const code = err.detail?.webDriverError;
+  return typeof code === 'string' && RECOVERABLE_CLICK_ERRORS.has(code);
+}
+
+/**
+ * Try one native click immediately, then fall back to the previous
+ * wait-for-visible click path only for transient WebDriver click/find failures.
+ */
+export async function clickWithFastPath(
+  resolveOnce: () => Promise<WebElement | null>,
+  waitForVisible: (timeout: number) => Promise<WebElement>,
+  timeout: number
+): Promise<void> {
+  const deadline = Date.now() + timeout;
+
+  try {
+    const el = await resolveOnce();
+    if (el) {
+      await el.click();
+      return;
+    }
+  } catch (err) {
+    if (!isRecoverableClickError(err)) throw err;
+    const remainingAfterError = Math.max(0, deadline - Date.now());
+    if (remainingAfterError <= 0) throw err;
+  }
+
+  const remaining = Math.max(0, deadline - Date.now());
+  const el = await waitForVisible(remaining);
+  await el.click();
+}

--- a/src/lib/elementHandle.ts
+++ b/src/lib/elementHandle.ts
@@ -6,6 +6,7 @@ import fs from 'fs/promises';
 import { expectSelector } from './expect.js';
 import { getKeyValue, type KeyValue } from './keys.js';
 import { A11y } from './a11y.js';
+import { clickWithFastPath } from './clickFastPath.js';
 
 export interface ElementOptions {
   timeout?: number;
@@ -79,9 +80,17 @@ export class ElementHandle {
   }
 
   async click(options?: ElementOptions): Promise<void> {
+    const timeout = options?.timeout ?? this.getDefaultTimeout();
     return this._withContext(async () => {
-      const el = await this._resolveVisible(options);
-      await el.click();
+      if (this._webElement) {
+        await this._webElement.click();
+        return;
+      }
+      await clickWithFastPath(
+        () => this.driver.findElement(this.by),
+        (remaining) => this._resolveVisible({ timeout: remaining }),
+        timeout
+      );
     });
   }
 

--- a/src/lib/frame.ts
+++ b/src/lib/frame.ts
@@ -20,6 +20,7 @@ import type { WebElement } from './webelement.js';
 import type { BiDiConnection } from './bidi/connection.js';
 import type { ScriptEvaluateResult, RemoteValue } from './bidi/types.js';
 import { DEFAULT_NAVIGATION_TIMEOUT_MS, STATE_POLL_INTERVAL_MS } from './timing.js';
+import { clickWithFastPath } from './clickFastPath.js';
 
 type LoadState = 'load' | 'domcontentloaded';
 
@@ -98,12 +99,14 @@ export class Frame {
 
   async click(selector: string | By, opts?: { timeout?: number }): Promise<void> {
     const by = typeof selector === 'string' ? By.css(selector) : selector;
+    const timeout = opts?.timeout ?? this.getDefaultTimeout();
     await this.contextSwitcher.in();
     try {
-      const el = await this.driver.wait(until.elementIsVisible(by), {
-        timeout: opts?.timeout ?? this.getDefaultTimeout(),
-      });
-      await el.click();
+      await clickWithFastPath(
+        () => this.driver.findElement(by),
+        (remaining) => this.driver.wait(until.elementIsVisible(by), { timeout: remaining }),
+        timeout
+      );
     } finally {
       await this.contextSwitcher.out();
     }

--- a/src/lib/http.ts
+++ b/src/lib/http.ts
@@ -2,6 +2,7 @@ import http from 'http';
 import https from 'https';
 import { URL } from 'url';
 import type { CommandResponse, RequestOptions, WebDriverEndpoint } from './types.js';
+import { CraftdriverError, ErrorCode } from './errors.js';
 
 /**
  * One keep-alive `Agent` per endpoint, shared across every `HttpClient`
@@ -26,6 +27,68 @@ function getAgent(endpoint: WebDriverEndpoint): http.Agent | https.Agent {
     agents.set(key, agent);
   }
   return agent;
+}
+
+/**
+ * Build a `CraftdriverError` from a non-200 WebDriver response.
+ *
+ * Per the W3C WebDriver spec a *successful* command always replies HTTP 200;
+ * any other status is an error whose body is
+ * `{ value: { error, message, stacktrace } }`, where `error` is the spec's
+ * machine-readable JSON error code (e.g. `"stale element reference"`,
+ * `"element click intercepted"`). We surface `error`/`message` as
+ * `detail.webDriverError` / `detail.webDriverMessage` so recovery loops can
+ * classify the failure without string-scraping the human message.
+ *
+ * The status code is the sole gate for *whether* this is an error — never the
+ * body shape. A successful `executeScript`/`evaluate()` can legitimately return
+ * user data shaped like `{ error, message, stacktrace }` (e.g. serializing a
+ * caught `Error`), and that must not be misread as a protocol failure. When the
+ * body doesn't parse or doesn't carry the spec shape (proxy text, HTML error
+ * page, empty body) we fall back to the raw text.
+ */
+function buildDriverError(
+  status: number,
+  text: string,
+  method: string,
+  path: string
+): CraftdriverError {
+  let webDriverError: string | undefined;
+  let webDriverMessage: string | undefined;
+  let stacktrace: string | undefined;
+  try {
+    const parsed = JSON.parse(text) as {
+      value?: { error?: string; message?: string; stacktrace?: string };
+    };
+    const v = parsed?.value;
+    if (v && typeof v === 'object') {
+      if (typeof v.error === 'string') webDriverError = v.error;
+      if (typeof v.message === 'string') webDriverMessage = v.message;
+      if (typeof v.stacktrace === 'string') stacktrace = v.stacktrace;
+    }
+  } catch {
+    // Non-JSON error body — keep the raw text in detail below.
+  }
+
+  const summary = webDriverError
+    ? `${webDriverError}${webDriverMessage ? `: ${webDriverMessage}` : ''}`
+    : `HTTP ${status}${text ? `: ${text}` : ''}`;
+
+  return new CraftdriverError(
+    ErrorCode.DRIVER_ERROR,
+    `WebDriver command ${method} ${path} failed — ${summary}`,
+    {
+      detail: {
+        method,
+        path,
+        status,
+        ...(webDriverError !== undefined ? { webDriverError } : {}),
+        ...(webDriverMessage !== undefined ? { webDriverMessage } : {}),
+        ...(stacktrace !== undefined ? { stacktrace } : {}),
+        ...(webDriverError === undefined ? { body: text } : {}),
+      },
+    }
+  );
 }
 
 export class HttpClient {
@@ -54,13 +117,28 @@ export class HttpClient {
         const chunks: Buffer[] = [];
         res.on('data', (c: Buffer) => chunks.push(Buffer.from(c)));
         res.on('end', () => {
+          const status = res.statusCode ?? 0;
           const text = Buffer.concat(chunks).toString('utf8');
+
+          // W3C WebDriver: success is always HTTP 200; any other status is an
+          // error response. Gate on status alone (see buildDriverError) so a
+          // successful command returning error-shaped data is never misread.
+          if (status !== 200) {
+            return reject(buildDriverError(status, text, method, path));
+          }
+
           if (!text) return resolve({ value: undefined as unknown as T });
           try {
             const json = JSON.parse(text) as CommandResponse<T>;
             resolve(json);
-          } catch (e) {
-            reject(new Error(`Invalid JSON response: ${text}`));
+          } catch {
+            reject(
+              new CraftdriverError(
+                ErrorCode.DRIVER_ERROR,
+                `Invalid JSON in WebDriver response for ${method} ${path}: ${text}`,
+                { detail: { method, path, status, body: text } }
+              )
+            );
           }
         });
       });

--- a/src/lib/http.ts
+++ b/src/lib/http.ts
@@ -91,6 +91,22 @@ function buildDriverError(
   );
 }
 
+function buildTransportError(err: Error, method: string, path: string): CraftdriverError {
+  return new CraftdriverError(
+    ErrorCode.DRIVER_ERROR,
+    `WebDriver command ${method} ${path} failed — ${err.message}`,
+    {
+      detail: {
+        method,
+        path,
+        transportError: err.name,
+        transportMessage: err.message,
+      },
+      cause: err,
+    }
+  );
+}
+
 export class HttpClient {
   constructor(private endpoint: WebDriverEndpoint) {}
 
@@ -116,6 +132,7 @@ export class HttpClient {
       const req = transport.request(url, options, (res: http.IncomingMessage) => {
         const chunks: Buffer[] = [];
         res.on('data', (c: Buffer) => chunks.push(Buffer.from(c)));
+        res.on('error', (err: Error) => reject(buildTransportError(err, method, path)));
         res.on('end', () => {
           const status = res.statusCode ?? 0;
           const text = Buffer.concat(chunks).toString('utf8');
@@ -142,7 +159,7 @@ export class HttpClient {
           }
         });
       });
-      req.on('error', reject);
+      req.on('error', (err: Error) => reject(buildTransportError(err, method, path)));
       if (payload) req.write(payload);
       req.end();
     });

--- a/src/lib/locator.ts
+++ b/src/lib/locator.ts
@@ -7,6 +7,7 @@ import type { ExpectApi } from './expect.js';
 import { A11y } from './a11y.js';
 import { CraftdriverError, ErrorCode } from './errors.js';
 import { DEFAULT_POLL_INTERVAL_MS } from './timing.js';
+import { clickWithFastPath } from './clickFastPath.js';
 
 export interface ActionOptions {
   timeout?: number;
@@ -204,6 +205,12 @@ export class Locator {
     return this._waitForVisible(timeout);
   }
 
+  /** Resolve the current final match once without waiting. */
+  private async _resolveOnce(): Promise<WebElement | null> {
+    const els = await this._findFinal();
+    return els.length > 0 ? els[0] : null;
+  }
+
   private async _resolveExisting(options?: ActionOptions): Promise<WebElement> {
     const timeout = options?.timeout ?? this.getDefaultTimeout();
     return this._waitForAny(timeout);
@@ -226,9 +233,13 @@ export class Locator {
   }
 
   async click(options?: ActionOptions): Promise<void> {
+    const timeout = options?.timeout ?? this.getDefaultTimeout();
     return this._withContext(async () => {
-      const el = await this._waitForVisibleOrSimple(options);
-      await el.click();
+      await clickWithFastPath(
+        () => this._resolveOnce(),
+        (remaining) => this._waitForVisibleOrSimple({ timeout: remaining }),
+        timeout
+      );
     });
   }
 

--- a/src/lib/page.ts
+++ b/src/lib/page.ts
@@ -67,7 +67,11 @@ export class Page {
 
   /** Switch the Classic driver to this window for element operations. */
   private async _activate(): Promise<string> {
-    const prev = await this.driver.getCurrentWindowHandle();
+    // The current Classic window may already be closed (e.g. a sibling
+    // BrowserContext closed its window and left focus dangling). Reading it must
+    // not abort activation — there's simply no previous handle to restore to, so
+    // fall back to '' and switch to this page. Mirrors browser.ts's guarded read.
+    const prev = await this.driver.getCurrentWindowHandle().catch(() => '');
     if (prev !== this.contextId) {
       await this.driver.switchToWindow(this.contextId);
     }
@@ -76,7 +80,9 @@ export class Page {
 
   /** Switch back to the previous window after a Classic action. */
   private async _restoreTo(handle: string): Promise<void> {
-    if (handle !== this.contextId) {
+    // Empty handle = there was no valid previous window (see _activate); leaving
+    // focus on this page is the correct fallback, so don't switch to ''.
+    if (handle && handle !== this.contextId) {
       await this.driver.switchToWindow(handle);
     }
   }

--- a/src/lib/page.ts
+++ b/src/lib/page.ts
@@ -23,6 +23,7 @@ import type { ScriptEvaluateResult, RemoteValue } from './bidi/types.js';
 import { DEFAULT_NAVIGATION_TIMEOUT_MS, STATE_POLL_INTERVAL_MS } from './timing.js';
 import type { BrowserContext } from './browserContext.js';
 import { CraftdriverError, ErrorCode } from './errors.js';
+import { clickWithFastPath } from './clickFastPath.js';
 
 type LoadState = 'load' | 'domcontentloaded' | 'networkidle' | 'none';
 
@@ -67,11 +68,7 @@ export class Page {
 
   /** Switch the Classic driver to this window for element operations. */
   private async _activate(): Promise<string> {
-    // The current Classic window may already be closed (e.g. a sibling
-    // BrowserContext closed its window and left focus dangling). Reading it must
-    // not abort activation — there's simply no previous handle to restore to, so
-    // fall back to '' and switch to this page. Mirrors browser.ts's guarded read.
-    const prev = await this.driver.getCurrentWindowHandle().catch(() => '');
+    const prev = await this.driver.getCurrentWindowHandle();
     if (prev !== this.contextId) {
       await this.driver.switchToWindow(this.contextId);
     }
@@ -80,9 +77,7 @@ export class Page {
 
   /** Switch back to the previous window after a Classic action. */
   private async _restoreTo(handle: string): Promise<void> {
-    // Empty handle = there was no valid previous window (see _activate); leaving
-    // focus on this page is the correct fallback, so don't switch to ''.
-    if (handle && handle !== this.contextId) {
+    if (handle !== this.contextId) {
       await this.driver.switchToWindow(handle);
     }
   }
@@ -400,11 +395,13 @@ export class Page {
 
   async click(selector: string | By, opts?: { timeout?: number }): Promise<void> {
     const by = typeof selector === 'string' ? By.css(selector) : selector;
+    const timeout = opts?.timeout ?? this.getDefaultTimeout();
     return this._withWindow(async () => {
-      const el = await this.driver.wait(until.elementIsVisible(by), {
-        timeout: opts?.timeout ?? this.getDefaultTimeout(),
-      });
-      await el.click();
+      await clickWithFastPath(
+        () => this.driver.findElement(by),
+        (remaining) => this.driver.wait(until.elementIsVisible(by), { timeout: remaining }),
+        timeout
+      );
     });
   }
 

--- a/src/lib/page.ts
+++ b/src/lib/page.ts
@@ -27,6 +27,11 @@ import { clickWithFastPath } from './clickFastPath.js';
 
 type LoadState = 'load' | 'domcontentloaded' | 'networkidle' | 'none';
 
+function isNoSuchWindowError(err: unknown): boolean {
+  if (!CraftdriverError.is(err, ErrorCode.DRIVER_ERROR)) return false;
+  return err.detail?.webDriverError === 'no such window' || err.message.includes('no such window');
+}
+
 export class Page {
   private driver: Driver;
   private getDefaultTimeout: () => number;
@@ -67,8 +72,13 @@ export class Page {
   }
 
   /** Switch the Classic driver to this window for element operations. */
-  private async _activate(): Promise<string> {
-    const prev = await this.driver.getCurrentWindowHandle();
+  private async _activate(): Promise<string | undefined> {
+    let prev: string | undefined;
+    try {
+      prev = await this.driver.getCurrentWindowHandle();
+    } catch (err) {
+      if (!isNoSuchWindowError(err)) throw err;
+    }
     if (prev !== this.contextId) {
       await this.driver.switchToWindow(this.contextId);
     }
@@ -76,9 +86,14 @@ export class Page {
   }
 
   /** Switch back to the previous window after a Classic action. */
-  private async _restoreTo(handle: string): Promise<void> {
+  private async _restoreTo(handle: string | undefined): Promise<void> {
     if (handle !== this.contextId) {
-      await this.driver.switchToWindow(handle);
+      if (!handle) return;
+      try {
+        await this.driver.switchToWindow(handle);
+      } catch (err) {
+        if (!isNoSuchWindowError(err)) throw err;
+      }
     }
   }
 
@@ -350,7 +365,7 @@ export class Page {
   private _makeContextSwitcher() {
     // Always switch Classic window to this context for element operations.
     // In Chrome, BiDi context IDs equal Classic window handles.
-    let savedHandle: string;
+    let savedHandle: string | undefined;
     return {
       in: async () => {
         savedHandle = await this._activate();

--- a/src/lib/wait.ts
+++ b/src/lib/wait.ts
@@ -12,6 +12,12 @@ export interface WaitOptions {
   timeoutMsg?: string;
 }
 
+function isTransientWaitError(err: unknown): boolean {
+  if (!CraftdriverError.is(err, ErrorCode.DRIVER_ERROR)) return false;
+  const webDriverError = err.detail?.webDriverError;
+  return webDriverError === 'no such element' || webDriverError === 'stale element reference';
+}
+
 export class WebDriverWait {
   private timeoutMs: number;
   private intervalMs: number;
@@ -49,8 +55,8 @@ export class WebDriverWait {
     }
     const errMsg = message ?? this.timeoutMsg ?? `Wait timed out after ${this.timeoutMs}ms`;
     const full = lastErr ? `${errMsg}: ${String((lastErr as any)?.message ?? lastErr)}` : errMsg;
-    // Preserve a more specific code when the inner condition already raised one.
-    if (CraftdriverError.is(lastErr)) {
+    // Preserve specific condition errors, but keep normal polling misses as TIMEOUT.
+    if (CraftdriverError.is(lastErr) && !isTransientWaitError(lastErr)) {
       throw new CraftdriverError(lastErr.code, full, {
         detail: { ...(lastErr.detail ?? {}), timeout: this.timeoutMs },
         cause: lastErr,

--- a/tests/error-codes.test.ts
+++ b/tests/error-codes.test.ts
@@ -84,6 +84,52 @@ describe('error codes', () => {
     expect(CraftdriverError.is(err, ErrorCode.EVAL_THREW)).toBe(true);
   });
 
+  // ── Phase 0: WebDriver protocol errors surface as DRIVER_ERROR ────────────
+  // A snapshot handle from findAll() clicks its captured element directly with
+  // no retry, so a genuine protocol failure (stale / intercepted) surfaces raw
+  // instead of being retried away — the ideal probe for the HTTP-layer fix.
+
+  it('clicking a snapshot handle whose element was removed throws DRIVER_ERROR (stale)', async () => {
+    const [handle] = await browser.findAll('#username');
+    await browser.evaluate(() => document.getElementById('username')?.remove());
+    let err: unknown;
+    try {
+      await handle.click();
+    } catch (e) {
+      err = e;
+    }
+    expect(CraftdriverError.is(err, ErrorCode.DRIVER_ERROR)).toBe(true);
+    expect(String((err as CraftdriverError).detail?.webDriverError)).toContain('stale element');
+  });
+
+  it('clicking a snapshot handle covered by an overlay throws DRIVER_ERROR (intercepted)', async () => {
+    const [handle] = await browser.findAll('#username');
+    await browser.evaluate(() => {
+      const overlay = document.createElement('div');
+      overlay.id = 'cover';
+      overlay.style.position = 'fixed';
+      overlay.style.inset = '0';
+      overlay.style.background = 'rgba(0,0,0,0.01)';
+      overlay.style.zIndex = '99999';
+      document.body.appendChild(overlay);
+    });
+    let err: unknown;
+    try {
+      await handle.click();
+    } catch (e) {
+      err = e;
+    }
+    expect(CraftdriverError.is(err, ErrorCode.DRIVER_ERROR)).toBe(true);
+    expect(String((err as CraftdriverError).detail?.webDriverError)).toContain('intercepted');
+  });
+
+  it('evaluate() returning error-shaped data resolves — status gating, not body shape', async () => {
+    // Regression guard: a *successful* command whose value happens to look like
+    // a WebDriver error body must NOT be misread as a protocol failure.
+    const result = await browser.evaluate(() => ({ error: 'x', message: 'y', stacktrace: 'z' }));
+    expect(result).toEqual({ error: 'x', message: 'y', stacktrace: 'z' });
+  });
+
   it('stopTrace() without startTrace() throws STATE_INVALID', async () => {
     let err: unknown;
     try {

--- a/tests/mcp-smoke.test.ts
+++ b/tests/mcp-smoke.test.ts
@@ -194,4 +194,26 @@ describe('MCP smoke', () => {
       /^(NO_MATCH|TIMEOUT(_WAITING_(VISIBLE|STATE))?)$/,
     );
   });
+
+  it('surfaces WebDriver protocol detail in structured errors', async () => {
+    const resp = (await mcp.request('tools/call', {
+      name: 'browser_click',
+      arguments: { selector: '[', timeout_ms: 200 },
+    })) as RpcSuccess;
+    const result = resp.result as {
+      isError: boolean;
+      structuredContent: {
+        error: {
+          code: string;
+          detail?: Record<string, unknown>;
+        };
+      };
+    };
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent.error.code).toBe('DRIVER_ERROR');
+    expect(result.structuredContent.error.detail).toMatchObject({
+      webDriverError: 'invalid selector',
+    });
+    expect(result.structuredContent.error.detail?.stacktrace).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary

- Surface WebDriver protocol errors as `DRIVER_ERROR`.
- Try native click immediately, then fall back to the old wait-for-visible click path on recoverable WebDriver errors.
- Apply only to click APIs; `fill()` and other actions stay unchanged.

## Verification

- `npm run build`
- `HEADLESS=true npx vitest run tests/error-codes.test.ts tests/pages.test.ts tests/iframes.test.ts tests/locator.test.ts tests/element-handle.test.ts --maxWorkers=1`