### PR TITLE
perf: optimize fill without implicit click

### DIFF
--- a/src/lib/browser.ts
+++ b/src/lib/browser.ts
@@ -48,6 +48,7 @@ import { A11y } from './a11y.js';
 import { Clock } from './clock.js';
 import { CraftdriverError, ErrorCode } from './errors.js';
 import { clickWithFastPath } from './clickFastPath.js';
+import { fillWithFastPath } from './fillFastPath.js';
 
 /** Device metrics for custom mobile emulation */
 export interface DeviceMetrics {
@@ -2121,12 +2122,13 @@ export class Browser {
   ): Promise<void> {
     if (this._tracer?.isRunning) this._tracer.recordAction('fill', [text], selectorToString(selector));
     const by = typeof selector === 'string' ? By.css(selector) : selector;
-    const el = await this.driver.wait(until.elementIsVisible(by), {
-      timeout: opts?.timeout ?? this.defaults.timeout,
-    });
-    await el.click();
-    await el.clear();
-    await el.sendKeys(text);
+    const timeout = opts?.timeout ?? this.defaults.timeout;
+    await fillWithFastPath(
+      () => this.driver.findElement(by),
+      (remaining) => this.driver.wait(until.elementIsVisible(by), { timeout: remaining }),
+      text,
+      timeout
+    );
   }
 
   async clear(selector: string | By, opts?: { timeout?: number }): Promise<void> {

--- a/src/lib/elementHandle.ts
+++ b/src/lib/elementHandle.ts
@@ -7,6 +7,7 @@ import { expectSelector } from './expect.js';
 import { getKeyValue, type KeyValue } from './keys.js';
 import { A11y } from './a11y.js';
 import { clickWithFastPath } from './clickFastPath.js';
+import { fillWithFastPath } from './fillFastPath.js';
 
 export interface ElementOptions {
   timeout?: number;
@@ -95,11 +96,16 @@ export class ElementHandle {
   }
 
   async fill(text: string, options?: ElementOptions): Promise<void> {
+    const timeout = options?.timeout ?? this.getDefaultTimeout();
     return this._withContext(async () => {
-      const el = await this._resolveVisible(options);
-      await el.click();
-      await el.clear();
-      await el.sendKeys(text);
+      await fillWithFastPath(
+        () => this._webElement
+          ? Promise.resolve(this._webElement)
+          : this.driver.findElement(this.by),
+        (remaining) => this._resolveVisible({ timeout: remaining }),
+        text,
+        timeout
+      );
     });
   }
 

--- a/src/lib/fillFastPath.ts
+++ b/src/lib/fillFastPath.ts
@@ -1,0 +1,48 @@
+import { CraftdriverError, ErrorCode } from './errors.js';
+import type { WebElement } from './webelement.js';
+
+const RECOVERABLE_FILL_ERRORS: ReadonlySet<string> = new Set([
+  'no such element',
+  'stale element reference',
+  'element not interactable',
+]);
+
+function isRecoverableFillError(err: unknown): boolean {
+  if (!CraftdriverError.is(err, ErrorCode.DRIVER_ERROR)) return false;
+  const code = err.detail?.webDriverError;
+  return typeof code === 'string' && RECOVERABLE_FILL_ERRORS.has(code);
+}
+
+async function fillElement(el: WebElement, text: string): Promise<void> {
+  await el.clear();
+  await el.sendKeys(text);
+}
+
+/**
+ * Try the native fill commands immediately, then fall back to the previous
+ * wait-for-visible fill path for transient find/interactability failures.
+ */
+export async function fillWithFastPath(
+  resolveOnce: () => Promise<WebElement | null>,
+  waitForVisible: (timeout: number) => Promise<WebElement>,
+  text: string,
+  timeout: number
+): Promise<void> {
+  const deadline = Date.now() + timeout;
+
+  try {
+    const el = await resolveOnce();
+    if (el) {
+      await fillElement(el, text);
+      return;
+    }
+  } catch (err) {
+    if (!isRecoverableFillError(err)) throw err;
+    const remainingAfterError = Math.max(0, deadline - Date.now());
+    if (remainingAfterError <= 0) throw err;
+  }
+
+  const remaining = Math.max(0, deadline - Date.now());
+  const el = await waitForVisible(remaining);
+  await fillElement(el, text);
+}

--- a/src/lib/frame.ts
+++ b/src/lib/frame.ts
@@ -21,6 +21,7 @@ import type { BiDiConnection } from './bidi/connection.js';
 import type { ScriptEvaluateResult, RemoteValue } from './bidi/types.js';
 import { DEFAULT_NAVIGATION_TIMEOUT_MS, STATE_POLL_INTERVAL_MS } from './timing.js';
 import { clickWithFastPath } from './clickFastPath.js';
+import { fillWithFastPath } from './fillFastPath.js';
 
 type LoadState = 'load' | 'domcontentloaded';
 
@@ -114,14 +115,15 @@ export class Frame {
 
   async fill(selector: string | By, text: string, opts?: { timeout?: number }): Promise<void> {
     const by = typeof selector === 'string' ? By.css(selector) : selector;
+    const timeout = opts?.timeout ?? this.getDefaultTimeout();
     await this.contextSwitcher.in();
     try {
-      const el = await this.driver.wait(until.elementIsVisible(by), {
-        timeout: opts?.timeout ?? this.getDefaultTimeout(),
-      });
-      await el.click();
-      await el.clear();
-      await el.sendKeys(text);
+      await fillWithFastPath(
+        () => this.driver.findElement(by),
+        (remaining) => this.driver.wait(until.elementIsVisible(by), { timeout: remaining }),
+        text,
+        timeout
+      );
     } finally {
       await this.contextSwitcher.out();
     }

--- a/src/lib/locator.ts
+++ b/src/lib/locator.ts
@@ -8,6 +8,7 @@ import { A11y } from './a11y.js';
 import { CraftdriverError, ErrorCode } from './errors.js';
 import { DEFAULT_POLL_INTERVAL_MS } from './timing.js';
 import { clickWithFastPath } from './clickFastPath.js';
+import { fillWithFastPath } from './fillFastPath.js';
 
 export interface ActionOptions {
   timeout?: number;
@@ -244,11 +245,14 @@ export class Locator {
   }
 
   async fill(text: string, options?: ActionOptions): Promise<void> {
+    const timeout = options?.timeout ?? this.getDefaultTimeout();
     return this._withContext(async () => {
-      const el = await this._waitForVisibleOrSimple(options);
-      await el.click();
-      await el.clear();
-      await el.sendKeys(text);
+      await fillWithFastPath(
+        () => this._resolveOnce(),
+        (remaining) => this._waitForVisibleOrSimple({ timeout: remaining }),
+        text,
+        timeout
+      );
     });
   }
 

--- a/src/lib/page.ts
+++ b/src/lib/page.ts
@@ -24,6 +24,7 @@ import { DEFAULT_NAVIGATION_TIMEOUT_MS, STATE_POLL_INTERVAL_MS } from './timing.
 import type { BrowserContext } from './browserContext.js';
 import { CraftdriverError, ErrorCode } from './errors.js';
 import { clickWithFastPath } from './clickFastPath.js';
+import { fillWithFastPath } from './fillFastPath.js';
 
 type LoadState = 'load' | 'domcontentloaded' | 'networkidle' | 'none';
 
@@ -422,13 +423,14 @@ export class Page {
 
   async fill(selector: string | By, text: string, opts?: { timeout?: number }): Promise<void> {
     const by = typeof selector === 'string' ? By.css(selector) : selector;
+    const timeout = opts?.timeout ?? this.getDefaultTimeout();
     return this._withWindow(async () => {
-      const el = await this.driver.wait(until.elementIsVisible(by), {
-        timeout: opts?.timeout ?? this.getDefaultTimeout(),
-      });
-      await el.click();
-      await el.clear();
-      await el.sendKeys(text);
+      await fillWithFastPath(
+        () => this.driver.findElement(by),
+        (remaining) => this.driver.wait(until.elementIsVisible(by), { timeout: remaining }),
+        text,
+        timeout
+      );
     });
   }
 

--- a/tests/element-handle.test.ts
+++ b/tests/element-handle.test.ts
@@ -176,6 +176,35 @@ describe('Browser-level element methods', () => {
     await browser.expect('#username').toHaveValue('replaced');
   });
 
+  it('fill() does not click the target before typing', async () => {
+    await browser.evaluate(() => {
+      (window as any).__fillClickCount = 0;
+      document.getElementById('username')?.addEventListener('click', () => {
+        (window as any).__fillClickCount += 1;
+      });
+    });
+
+    await browser.fill('#username', 'typed');
+
+    expect(await browser.evaluate(() => (window as any).__fillClickCount)).toBe(0);
+  });
+
+  it('fill() waits for an attached input to become visible', async () => {
+    await browser.evaluate(() => {
+      const input = document.createElement('input');
+      input.id = 'delayed-fill';
+      input.style.display = 'none';
+      document.body.appendChild(input);
+      setTimeout(() => {
+        input.style.display = 'block';
+      }, 300);
+    });
+
+    await browser.fill('#delayed-fill', 'visible now', { timeout: 3000 });
+
+    await browser.expect('#delayed-fill').toHaveValue('visible now');
+  });
+
   it('clear() removes text from input', async () => {
     await browser.fill('#username', 'some text');
     await browser.clear('#username');


### PR DESCRIPTION
### Summary

This makes `fill` more explicit: it fills the target without performing an implicit `click` first. If a flow needs focus/click behavior, callers can request it explicitly with `click()` before `fill()`.

It also improves performance by avoiding an extra WebDriver command on the common fill path.

No negative stability impact observed: the regression suite is passing.