### PR TITLE
perf: extend fast-path pattern to clear(), press(), and hover()

### DIFF
--- a/src/lib/browser.ts
+++ b/src/lib/browser.ts
@@ -49,6 +49,7 @@ import { Clock } from './clock.js';
 import { CraftdriverError, ErrorCode } from './errors.js';
 import { clickWithFastPath } from './clickFastPath.js';
 import { fillWithFastPath } from './fillFastPath.js';
+import { clearWithFastPath } from './clearFastPath.js';
 
 /** Device metrics for custom mobile emulation */
 export interface DeviceMetrics {
@@ -2134,10 +2135,12 @@ export class Browser {
   async clear(selector: string | By, opts?: { timeout?: number }): Promise<void> {
     if (this._tracer?.isRunning) this._tracer.recordAction('clear', undefined, selectorToString(selector));
     const by = typeof selector === 'string' ? By.css(selector) : selector;
-    const el = await this.driver.wait(until.elementIsVisible(by), {
-      timeout: opts?.timeout ?? this.defaults.timeout,
-    });
-    await el.clear();
+    const timeout = opts?.timeout ?? this.defaults.timeout;
+    await clearWithFastPath(
+      () => this.driver.findElement(by),
+      (remaining) => this.driver.wait(until.elementIsVisible(by), { timeout: remaining }),
+      timeout
+    );
   }
 
   async getValue(selector: string | By, opts?: { timeout?: number }): Promise<string> {

--- a/src/lib/clearFastPath.ts
+++ b/src/lib/clearFastPath.ts
@@ -1,0 +1,42 @@
+import { CraftdriverError, ErrorCode } from './errors.js';
+import type { WebElement } from './webelement.js';
+
+const RECOVERABLE_CLEAR_ERRORS: ReadonlySet<string> = new Set([
+  'no such element',
+  'stale element reference',
+  'element not interactable',
+]);
+
+function isRecoverableClearError(err: unknown): boolean {
+  if (!CraftdriverError.is(err, ErrorCode.DRIVER_ERROR)) return false;
+  const code = err.detail?.webDriverError;
+  return typeof code === 'string' && RECOVERABLE_CLEAR_ERRORS.has(code);
+}
+
+/**
+ * Try the native clear command immediately, then fall back to the previous
+ * wait-for-visible clear path for transient find/interactability failures.
+ */
+export async function clearWithFastPath(
+  resolveOnce: () => Promise<WebElement | null>,
+  waitForVisible: (timeout: number) => Promise<WebElement>,
+  timeout: number
+): Promise<void> {
+  const deadline = Date.now() + timeout;
+
+  try {
+    const el = await resolveOnce();
+    if (el) {
+      await el.clear();
+      return;
+    }
+  } catch (err) {
+    if (!isRecoverableClearError(err)) throw err;
+    const remainingAfterError = Math.max(0, deadline - Date.now());
+    if (remainingAfterError <= 0) throw err;
+  }
+
+  const remaining = Math.max(0, deadline - Date.now());
+  const el = await waitForVisible(remaining);
+  await el.clear();
+}

--- a/src/lib/driver.ts
+++ b/src/lib/driver.ts
@@ -3,6 +3,12 @@ import type { Capabilities, SessionResponse, WebDriverEndpoint, CommandResponse 
 import { By } from './by.js';
 import { WebElement, W3C_ELEMENT_KEY, LEGACY_ELEMENT_KEY } from './webelement.js';
 import { WebDriverWait, type Condition, type WaitOptions } from './wait.js';
+import { CraftdriverError, ErrorCode } from './errors.js';
+
+function isMoveTargetOutOfBounds(err: unknown): boolean {
+  if (!CraftdriverError.is(err, ErrorCode.DRIVER_ERROR)) return false;
+  return err.detail?.webDriverError === 'move target out of bounds';
+}
 
 export class Driver {
   /** BiDi WebSocket URL if available */
@@ -268,7 +274,7 @@ export class Driver {
       pointerMove.x = x ?? 0;
       pointerMove.y = y ?? 0;
     }
-    await client.send({
+    const sendMove = () => client.send({
       method: 'POST',
       path: `/session/${this.sessionId}/actions`,
       body: {
@@ -282,6 +288,18 @@ export class Driver {
         ],
       },
     });
+
+    try {
+      await sendMove();
+    } catch (err) {
+      if (!originElement || !isMoveTargetOutOfBounds(err)) throw err;
+      // Chromedriver scrolls element-origin moves; geckodriver may require it explicitly.
+      await this.executeScript(
+        `arguments[0].scrollIntoView({ block: 'center', inline: 'center' });`,
+        [originElement]
+      );
+      await sendMove();
+    }
   }
 
   async mouseDown(button: number = 0): Promise<void> {

--- a/src/lib/elementHandle.ts
+++ b/src/lib/elementHandle.ts
@@ -8,6 +8,7 @@ import { getKeyValue, type KeyValue } from './keys.js';
 import { A11y } from './a11y.js';
 import { clickWithFastPath } from './clickFastPath.js';
 import { fillWithFastPath } from './fillFastPath.js';
+import { clearWithFastPath } from './clearFastPath.js';
 
 export interface ElementOptions {
   timeout?: number;
@@ -110,16 +111,30 @@ export class ElementHandle {
   }
 
   async clear(options?: ElementOptions): Promise<void> {
+    const timeout = options?.timeout ?? this.getDefaultTimeout();
     return this._withContext(async () => {
-      const el = await this._resolveVisible(options);
-      await el.clear();
+      await clearWithFastPath(
+        () => this._webElement
+          ? Promise.resolve(this._webElement)
+          : this.driver.findElement(this.by),
+        (remaining) => this._resolveVisible({ timeout: remaining }),
+        timeout
+      );
     });
   }
 
   async press(key: KeyValue, options?: ElementOptions): Promise<void> {
+    const timeout = options?.timeout ?? this.getDefaultTimeout();
     return this._withContext(async () => {
-      const el = await this._resolveVisible(options);
-      await el.click();
+      if (this._webElement) {
+        await this._webElement.click();
+      } else {
+        await clickWithFastPath(
+          () => this.driver.findElement(this.by),
+          (remaining) => this._resolveVisible({ timeout: remaining }),
+          timeout
+        );
+      }
       const code = getKeyValue(key);
       await this.driver.keyPressCode(code, 1);
     });
@@ -212,10 +227,7 @@ export class ElementHandle {
   async hover(options?: ElementOptions): Promise<void> {
     return this._withContext(async () => {
       const el = await this._resolveVisible(options);
-      const rect = await el.getRect();
-      const centerX = rect.x + rect.width / 2;
-      const centerY = rect.y + rect.height / 2;
-      await this.driver.pointerMoveTo(undefined, centerX, centerY);
+      await this.driver.pointerMoveTo(el);
     });
   }
 

--- a/src/lib/elementHandle.ts
+++ b/src/lib/elementHandle.ts
@@ -9,6 +9,7 @@ import { A11y } from './a11y.js';
 import { clickWithFastPath } from './clickFastPath.js';
 import { fillWithFastPath } from './fillFastPath.js';
 import { clearWithFastPath } from './clearFastPath.js';
+import { withApiCallStack } from './errors.js';
 
 export interface ElementOptions {
   timeout?: number;
@@ -39,16 +40,19 @@ export class ElementHandle {
     return this;
   }
 
-  private async _withContext<T>(fn: () => Promise<T>): Promise<T> {
-    if (this._contextSwitcher) {
-      await this._contextSwitcher.in();
-      try {
-        return await fn();
-      } finally {
-        await this._contextSwitcher.out();
+  private async _withContext<T>(fn: () => Promise<T>, callerFn?: Function): Promise<T> {
+    const run = async () => {
+      if (this._contextSwitcher) {
+        await this._contextSwitcher.in();
+        try {
+          return await fn();
+        } finally {
+          await this._contextSwitcher.out();
+        }
       }
-    }
-    return fn();
+      return fn();
+    };
+    return callerFn ? withApiCallStack(callerFn, run) : run();
   }
 
   /**
@@ -93,7 +97,7 @@ export class ElementHandle {
         (remaining) => this._resolveVisible({ timeout: remaining }),
         timeout
       );
-    });
+    }, ElementHandle.prototype.click);
   }
 
   async fill(text: string, options?: ElementOptions): Promise<void> {
@@ -107,7 +111,7 @@ export class ElementHandle {
         text,
         timeout
       );
-    });
+    }, ElementHandle.prototype.fill);
   }
 
   async clear(options?: ElementOptions): Promise<void> {
@@ -120,7 +124,7 @@ export class ElementHandle {
         (remaining) => this._resolveVisible({ timeout: remaining }),
         timeout
       );
-    });
+    }, ElementHandle.prototype.clear);
   }
 
   async press(key: KeyValue, options?: ElementOptions): Promise<void> {
@@ -137,7 +141,7 @@ export class ElementHandle {
       }
       const code = getKeyValue(key);
       await this.driver.keyPressCode(code, 1);
-    });
+    }, ElementHandle.prototype.press);
   }
 
   /**
@@ -155,14 +159,14 @@ export class ElementHandle {
       const buf = Buffer.from(b64, 'base64');
       if (opts?.path) await fs.writeFile(opts.path, buf);
       return buf;
-    });
+    }, ElementHandle.prototype.screenshot);
   }
 
   async text(options?: ElementOptions): Promise<string> {
     return this._withContext(async () => {
       const el = await this._resolveLocated(options);
       return el.getText();
-    });
+    }, ElementHandle.prototype.text);
   }
 
   async value(options?: ElementOptions): Promise<string> {
@@ -170,21 +174,21 @@ export class ElementHandle {
       const el = await this._resolveLocated(options);
       const val = await el.getProperty('value');
       return String(val ?? '');
-    });
+    }, ElementHandle.prototype.value);
   }
 
   async tagName(options?: ElementOptions): Promise<string> {
     return this._withContext(async () => {
       const el = await this._resolveLocated(options);
       return el.getTagName();
-    });
+    }, ElementHandle.prototype.tagName);
   }
 
   async getAttribute(name: string, options?: ElementOptions): Promise<string | null> {
     return this._withContext(async () => {
       const el = await this._resolveLocated(options);
       return el.getAttribute(name);
-    });
+    }, ElementHandle.prototype.getAttribute);
   }
 
   async isVisible(options?: ElementOptions): Promise<boolean> {
@@ -193,7 +197,7 @@ export class ElementHandle {
         const timeout = options?.timeout ?? Math.min(this.getDefaultTimeout(), 1000);
         const el = await this._resolveLocated({ timeout });
         return el.isDisplayed();
-      });
+      }, ElementHandle.prototype.isVisible);
     } catch {
       return false;
     }
@@ -203,14 +207,14 @@ export class ElementHandle {
     return this._withContext(async () => {
       const el = await this._resolveLocated(options);
       return el.isEnabled();
-    });
+    }, ElementHandle.prototype.isEnabled);
   }
 
   async isChecked(options?: ElementOptions): Promise<boolean> {
     return this._withContext(async () => {
       const el = await this._resolveLocated(options);
       return el.isSelected();
-    });
+    }, ElementHandle.prototype.isChecked);
   }
 
   async boundingBox(options?: ElementOptions): Promise<{ x: number; y: number; width: number; height: number } | null> {
@@ -218,7 +222,7 @@ export class ElementHandle {
       return await this._withContext(async () => {
         const el = await this._resolveLocated(options);
         return el.getRect();
-      });
+      }, ElementHandle.prototype.boundingBox);
     } catch {
       return null;
     }
@@ -228,7 +232,7 @@ export class ElementHandle {
     return this._withContext(async () => {
       const el = await this._resolveVisible(options);
       await this.driver.pointerMoveTo(el);
-    });
+    }, ElementHandle.prototype.hover);
   }
 
   async select(value: string, options?: ElementOptions): Promise<void> {
@@ -256,7 +260,7 @@ export class ElementHandle {
       `;
 
       await this.driver.executeScript(script, [el, value]);
-    });
+    }, ElementHandle.prototype.select);
   }
 
   expect() {
@@ -290,7 +294,7 @@ export class ElementHandle {
       }
 
       await el.sendKeys(paths.join('\n'));
-    });
+    }, ElementHandle.prototype.setInputFiles);
   }
 
   /**
@@ -314,7 +318,7 @@ export class ElementHandle {
         `return (${fnSrc}).apply(null, arguments)`,
         [el, ...args]
       );
-    });
+    }, ElementHandle.prototype.evaluate);
   }
 
   private _a11y?: A11y;

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -82,3 +82,35 @@ export class CraftdriverError extends Error {
     return code === undefined || err.code === code;
   }
 }
+
+type CapturedStack = { stack?: string };
+
+function captureStack(callerFn: Function): CapturedStack {
+  const captured: CapturedStack = {};
+  if (Error.captureStackTrace) {
+    Error.captureStackTrace(captured, callerFn);
+  } else {
+    captured.stack = new Error().stack;
+  }
+  return captured;
+}
+
+function applyCapturedStack(err: unknown, captured: CapturedStack): void {
+  if (!(err instanceof Error) || !captured.stack) return;
+
+  const frames = captured.stack.split('\n').slice(1);
+  err.stack = [`${err.name}: ${err.message}`, ...frames].join('\n');
+}
+
+export async function withApiCallStack<T>(
+  callerFn: Function,
+  action: () => Promise<T>
+): Promise<T> {
+  const captured = captureStack(callerFn);
+  try {
+    return await action();
+  } catch (err) {
+    applyCapturedStack(err, captured);
+    throw err;
+  }
+}

--- a/tests/a11y.test.ts
+++ b/tests/a11y.test.ts
@@ -30,18 +30,13 @@ describe('a11y (axe-core wrapper)', () => {
     expect(typeof v.helpUrl).toBe('string');
     expect(['minor', 'moderate', 'serious', 'critical']).toContain(v.impact);
     expect(typeof v.nodes[0].html).toBe('string');
-    expect(Array.isArray(v.nodes[0].target)).toBe(true);
+    expect(v.nodes[0].target).toEqual(expect.any(Array));
   });
 
   it('check() throws A11yError with violations and help URLs in the message', async () => {
-    let caught: unknown;
-    try {
-      await browser.a11y.check();
-    } catch (e) {
-      caught = e;
-    }
-    expect(caught).toBeInstanceOf(A11yError);
-    const err = caught as A11yError;
+    const err = (await browser.a11y.check().catch((e: unknown) => e)) as A11yError;
+
+    expect(err).toBeInstanceOf(A11yError);
     expect(err.violations.length).toBeGreaterThan(0);
     expect(err.message).toMatch(/violation/);
     expect(err.message).toMatch(/https?:\/\//);
@@ -78,7 +73,7 @@ describe('a11y (axe-core wrapper)', () => {
     // image-alt is critical — must still be present (guards against vacuous pass)
     expect(report.violations.map((v) => v.id)).toContain('image-alt');
     // nothing below critical should leak through
-    expect(report.violations.every((v) => v.impact === 'critical')).toBe(true);
+    expect(new Set(report.violations.map((v) => v.impact))).toEqual(new Set(['critical']));
   });
 
   it('scoping: #bad has violations, #good is clean and check() does not throw', async () => {

--- a/tests/api-reference.test.ts
+++ b/tests/api-reference.test.ts
@@ -9,6 +9,23 @@ const repoRoot = path.resolve(__dirname, '..');
 const apiReference = path.join(repoRoot, 'docs', 'api-reference.md');
 const generator = path.join(repoRoot, 'scripts', 'gen-api-reference.mjs');
 
+function exportedNames(source: string): Set<string> {
+  const blocks = source.matchAll(/export(?:\s+type)?\s*\{([\s\S]*?)\}/g);
+  const names = [...blocks].flatMap(([, block]) =>
+    block
+      .split(',')
+      .map((raw) =>
+        raw
+          .replace(/\btype\s+/, '')
+          .trim()
+          .split(/\s+as\s+/)[0]
+          .trim()
+      )
+      .filter(Boolean)
+  );
+  return new Set(names);
+}
+
 describe('docs/api-reference.md', () => {
   it('is in sync with src/index.ts (run `npm run docs:api`)', () => {
     // The --check mode exits non-zero when the file is stale.
@@ -16,21 +33,14 @@ describe('docs/api-reference.md', () => {
       execFileSync(process.execPath, [generator, '--check'], {
         cwd: repoRoot,
         stdio: 'pipe',
-      }),
+      })
     ).not.toThrow();
   });
 
   it('lists every named export from src/index.ts', () => {
     const indexSrc = fs.readFileSync(path.join(repoRoot, 'src', 'index.ts'), 'utf8');
-    // Match identifiers inside `export { ... }` and `export type { ... }` blocks.
-    const exportBlocks = [...indexSrc.matchAll(/export(?:\s+type)?\s*\{([\s\S]*?)\}/g)];
-    const names = new Set<string>();
-    for (const m of exportBlocks) {
-      for (const raw of m[1].split(',')) {
-        const cleaned = raw.replace(/\btype\s+/, '').trim().split(/\s+as\s+/)[0].trim();
-        if (cleaned) names.add(cleaned);
-      }
-    }
+    const names = exportedNames(indexSrc);
+
     expect(names.size).toBeGreaterThan(0);
     const table = fs.readFileSync(apiReference, 'utf8');
     const missing = [...names].filter((n) => !table.includes(`\`${n}\``));

--- a/tests/browser-context-emulation.test.ts
+++ b/tests/browser-context-emulation.test.ts
@@ -17,12 +17,26 @@
  */
 
 import { describe, it, beforeAll, afterAll, expect } from 'vitest';
-import { Browser } from '../src';
+import { Browser, type BrowserContext } from '../src';
 import { EXAMPLES_BASE_URL, BROWSER_NAME, IS_CHROMIUM } from './utils';
+
+type NewContextOptions = Parameters<Browser['newContext']>[0];
 
 describe('BrowserContext identity & device (Milestone C)', () => {
   let browser: Browser;
   const baseUrl = EXAMPLES_BASE_URL;
+
+  async function withContext<T>(
+    run: (ctx: BrowserContext) => Promise<T>,
+    options?: NewContextOptions
+  ): Promise<T> {
+    const ctx = await browser.newContext(options);
+    try {
+      return await run(ctx);
+    } finally {
+      await ctx.close();
+    }
+  }
 
   beforeAll(async () => {
     browser = await Browser.launch({ browserName: BROWSER_NAME });
@@ -34,21 +48,21 @@ describe('BrowserContext identity & device (Milestone C)', () => {
 
   // ── Locale ──────────────────────────────────────────────────────────────
 
-  it("newContext({ locale }) is reported by navigator.language and Intl", async () => {
-    const ctx = await browser.newContext({ locale: 'de-DE' });
-    try {
-      const page = await ctx.newPage({ url: `${baseUrl}/login.html` });
-      const lang = await page.evaluate<string>(`return navigator.language;`);
-      expect(lang).toBe('de-DE');
+  it('newContext({ locale }) is reported by navigator.language and Intl', async () => {
+    await withContext(
+      async (ctx) => {
+        const page = await ctx.newPage({ url: `${baseUrl}/login.html` });
+        const lang = await page.evaluate<string>(`return navigator.language;`);
+        expect(lang).toBe('de-DE');
 
-      // The locale should also drive Intl formatting (decimal comma in de-DE).
-      const formatted = await page.evaluate<string>(
-        `return new Intl.NumberFormat().format(1234.5);`
-      );
-      expect(formatted).toBe('1.234,5');
-    } finally {
-      await ctx.close();
-    }
+        // The locale should also drive Intl formatting (decimal comma in de-DE).
+        const formatted = await page.evaluate<string>(
+          `return new Intl.NumberFormat().format(1234.5);`
+        );
+        expect(formatted).toBe('1.234,5');
+      },
+      { locale: 'de-DE' }
+    );
   });
 
   it('locale is isolated between contexts', async () => {
@@ -68,52 +82,49 @@ describe('BrowserContext identity & device (Milestone C)', () => {
   });
 
   it('setLocale(null) clears the override at runtime', async () => {
-    const ctx = await browser.newContext({ locale: 'fr-FR' });
-    try {
-      const page = await ctx.newPage({ url: `${baseUrl}/login.html` });
-      expect(await page.evaluate<string>(`return navigator.language;`)).toBe('fr-FR');
+    await withContext(
+      async (ctx) => {
+        const page = await ctx.newPage({ url: `${baseUrl}/login.html` });
+        expect(await page.evaluate<string>(`return navigator.language;`)).toBe('fr-FR');
 
-      await ctx.setLocale(null);
-      // Re-read after navigation so the page picks up the cleared override.
-      await page.reload();
-      const cleared = await page.evaluate<string>(`return navigator.language;`);
-      expect(cleared).not.toBe('fr-FR');
-    } finally {
-      await ctx.close();
-    }
+        await ctx.setLocale(null);
+        // Re-read after navigation so the page picks up the cleared override.
+        await page.reload();
+        const cleared = await page.evaluate<string>(`return navigator.language;`);
+        expect(cleared).not.toBe('fr-FR');
+      },
+      { locale: 'fr-FR' }
+    );
   });
 
   // ── Timezone ────────────────────────────────────────────────────────────
 
   it('newContext({ timezoneId }) shifts Date / Intl.DateTimeFormat', async () => {
-    const ctx = await browser.newContext({ timezoneId: 'Asia/Tokyo' });
-    try {
-      const page = await ctx.newPage({ url: `${baseUrl}/login.html` });
-      // JST is UTC+9 year-round (no DST). getTimezoneOffset returns -540.
-      const offset = await page.evaluate<number>(`return new Date().getTimezoneOffset();`);
-      expect(offset).toBe(-540);
+    await withContext(
+      async (ctx) => {
+        const page = await ctx.newPage({ url: `${baseUrl}/login.html` });
+        // JST is UTC+9 year-round (no DST). getTimezoneOffset returns -540.
+        const offset = await page.evaluate<number>(`return new Date().getTimezoneOffset();`);
+        expect(offset).toBe(-540);
 
-      const resolved = await page.evaluate<string>(
-        `return Intl.DateTimeFormat().resolvedOptions().timeZone;`
-      );
-      expect(resolved).toBe('Asia/Tokyo');
-    } finally {
-      await ctx.close();
-    }
+        const resolved = await page.evaluate<string>(
+          `return Intl.DateTimeFormat().resolvedOptions().timeZone;`
+        );
+        expect(resolved).toBe('Asia/Tokyo');
+      },
+      { timezoneId: 'Asia/Tokyo' }
+    );
   });
 
   it('setTimezone applies to a page opened later in the same context', async () => {
-    const ctx = await browser.newContext();
-    try {
+    await withContext(async (ctx) => {
       await ctx.setTimezone('Europe/Berlin');
       const page = await ctx.newPage({ url: `${baseUrl}/login.html` });
       const tz = await page.evaluate<string>(
         `return Intl.DateTimeFormat().resolvedOptions().timeZone;`
       );
       expect(tz).toBe('Europe/Berlin');
-    } finally {
-      await ctx.close();
-    }
+    });
   });
 
   // ── Geolocation + permissions ───────────────────────────────────────────
@@ -123,14 +134,12 @@ describe('BrowserContext identity & device (Milestone C)', () => {
   it.skipIf(!IS_CHROMIUM)(
     'newContext({ geolocation }) is read by navigator.geolocation once permission is granted',
     async () => {
-      const ctx = await browser.newContext({
-        geolocation: { latitude: 51.5074, longitude: -0.1278 },
-      });
-      try {
-        const origin = baseUrl;
-        await ctx.grantPermissions(['geolocation'], { origin });
-        const page = await ctx.newPage({ url: `${baseUrl}/login.html` });
-        const coords = await page.evaluate<{ lat: number; lon: number }>(`
+      await withContext(
+        async (ctx) => {
+          const origin = baseUrl;
+          await ctx.grantPermissions(['geolocation'], { origin });
+          const page = await ctx.newPage({ url: `${baseUrl}/login.html` });
+          const coords = await page.evaluate<{ lat: number; lon: number }>(`
           return new Promise((resolve, reject) => {
             navigator.geolocation.getCurrentPosition(
               (pos) => resolve({ lat: pos.coords.latitude, lon: pos.coords.longitude }),
@@ -139,33 +148,25 @@ describe('BrowserContext identity & device (Milestone C)', () => {
             );
           });
         `);
-        expect(coords.lat).toBeCloseTo(51.5074, 3);
-        expect(coords.lon).toBeCloseTo(-0.1278, 3);
-      } finally {
-        await ctx.close();
-      }
+          expect(coords.lat).toBeCloseTo(51.5074, 3);
+          expect(coords.lon).toBeCloseTo(-0.1278, 3);
+        },
+        { geolocation: { latitude: 51.5074, longitude: -0.1278 } }
+      );
     }
   );
 
   it('grantPermissions requires an origin', async () => {
-    const ctx = await browser.newContext();
-    try {
+    await withContext(async (ctx) => {
       // @ts-expect-error — testing the runtime guard
       await expect(ctx.grantPermissions(['geolocation'], {})).rejects.toThrow(/origin/);
-    } finally {
-      await ctx.close();
-    }
+    });
   });
 
   it('setGeolocation validates coordinates', async () => {
-    const ctx = await browser.newContext();
-    try {
-      await expect(
-        ctx.setGeolocation({ latitude: 200, longitude: 0 })
-      ).rejects.toThrow(/latitude/);
-    } finally {
-      await ctx.close();
-    }
+    await withContext(async (ctx) => {
+      await expect(ctx.setGeolocation({ latitude: 200, longitude: 0 })).rejects.toThrow(/latitude/);
+    });
   });
 
   // ── Closed-context safety ───────────────────────────────────────────────
@@ -176,8 +177,8 @@ describe('BrowserContext identity & device (Milestone C)', () => {
     await expect(ctx.setLocale('de-DE')).rejects.toThrow(/closed/);
     await expect(ctx.setTimezone('UTC')).rejects.toThrow(/closed/);
     await expect(ctx.setGeolocation(null)).rejects.toThrow(/closed/);
-    await expect(
-      ctx.grantPermissions(['geolocation'], { origin: baseUrl })
-    ).rejects.toThrow(/closed/);
+    await expect(ctx.grantPermissions(['geolocation'], { origin: baseUrl })).rejects.toThrow(
+      /closed/
+    );
   });
 });

--- a/tests/browser-context-hooks.test.ts
+++ b/tests/browser-context-hooks.test.ts
@@ -16,12 +16,26 @@
  */
 
 import { describe, it, beforeAll, afterAll, expect } from 'vitest';
-import { Browser, Page } from '../src';
+import { Browser, Page, type BrowserContext } from '../src';
 import { EXAMPLES_BASE_URL, BROWSER_NAME } from './utils';
+
+type NewContextOptions = Parameters<Browser['newContext']>[0];
 
 describe('BrowserContext hooks & routing (Milestone B)', () => {
   let browser: Browser;
   const baseUrl = EXAMPLES_BASE_URL;
+
+  async function withContext<T>(
+    run: (ctx: BrowserContext) => Promise<T>,
+    options?: NewContextOptions
+  ): Promise<T> {
+    const ctx = await browser.newContext(options);
+    try {
+      return await run(ctx);
+    } finally {
+      await ctx.close();
+    }
+  }
 
   beforeAll(async () => {
     browser = await Browser.launch({ browserName: BROWSER_NAME });
@@ -34,16 +48,13 @@ describe('BrowserContext hooks & routing (Milestone B)', () => {
   // ── page.context() back-reference ──────────────────────────────────────
 
   it('page.context() points back to the owning BrowserContext', async () => {
-    const ctx = await browser.newContext();
-    try {
+    await withContext(async (ctx) => {
       const page = await ctx.newPage({ url: `${baseUrl}/login.html` });
       expect(page.context()).toBe(ctx);
 
       const [listed] = await ctx.pages();
       expect(listed.context()).toBe(ctx);
-    } finally {
-      await ctx.close();
-    }
+    });
   });
 
   it('Browser-level pages report defaultContext, and context wrappers are cached', async () => {
@@ -64,28 +75,28 @@ describe('BrowserContext hooks & routing (Milestone B)', () => {
   it('baseURL resolves relative paths in page.navigateTo()', async () => {
     // QA value: point one context at staging and all relative URLs in
     // tests "just work" without the hostname pasted everywhere.
-    const ctx = await browser.newContext({ baseURL: baseUrl });
-    try {
-      const page = await ctx.newPage();
-      await page.navigateTo('/login.html');
-      await page.waitForLoadState('load');
-      expect(await page.title()).toContain('Login');
-      expect((await page.url())?.endsWith('/login.html')).toBe(true);
-    } finally {
-      await ctx.close();
-    }
+    await withContext(
+      async (ctx) => {
+        const page = await ctx.newPage();
+        await page.navigateTo('/login.html');
+        await page.waitForLoadState('load');
+        expect(await page.title()).toContain('Login');
+        expect(await page.url()).toMatch(/\/login\.html$/);
+      },
+      { baseURL: baseUrl }
+    );
   });
 
   it('baseURL leaves absolute URLs untouched', async () => {
-    const ctx = await browser.newContext({ baseURL: 'https://nowhere.example.com' });
-    try {
-      const page = await ctx.newPage();
-      await page.navigateTo(`${baseUrl}/login.html`);
-      await page.waitForLoadState('load');
-      expect(await page.title()).toContain('Login');
-    } finally {
-      await ctx.close();
-    }
+    await withContext(
+      async (ctx) => {
+        const page = await ctx.newPage();
+        await page.navigateTo(`${baseUrl}/login.html`);
+        await page.waitForLoadState('load');
+        expect(await page.title()).toContain('Login');
+      },
+      { baseURL: 'https://nowhere.example.com' }
+    );
   });
 
   // ── extraHTTPHeaders ───────────────────────────────────────────────────
@@ -93,44 +104,40 @@ describe('BrowserContext hooks & routing (Milestone B)', () => {
   it('extraHTTPHeaders are sent on requests from this context only', async () => {
     // QA value: tag every request from a tenant's context with
     // `X-Tenant: acme` without modifying app code or wrapping fetch.
-    const tenant = await browser.newContext({
-      extraHTTPHeaders: { 'X-Tenant': 'acme' },
-    });
     const seenHeaders: Record<string, string> = {};
-    try {
-      // Capture the headers that hit the example server by intercepting
-      // the request inside the same context.
-      await tenant.route('**/login.html', (req) => {
-        for (const [k, v] of Object.entries(req.headers)) {
-          if (k.toLowerCase() === 'x-tenant') seenHeaders[k.toLowerCase()] = v;
-        }
-        // Continue with the real response.
-      });
-      const page = await tenant.newPage({ url: `${baseUrl}/login.html` });
-      await page.waitForLoadState('load');
-      expect(seenHeaders['x-tenant']).toBe('acme');
-    } finally {
-      await tenant.close();
-    }
+    await withContext(
+      async (tenant) => {
+        // Capture the headers that hit the example server by intercepting
+        // the request inside the same context.
+        await tenant.route('**/login.html', (req) => {
+          for (const [k, v] of Object.entries(req.headers)) {
+            if (k.toLowerCase() === 'x-tenant') seenHeaders[k.toLowerCase()] = v;
+          }
+          // Continue with the real response.
+        });
+        const page = await tenant.newPage({ url: `${baseUrl}/login.html` });
+        await page.waitForLoadState('load');
+        expect(seenHeaders['x-tenant']).toBe('acme');
+      },
+      { extraHTTPHeaders: { 'X-Tenant': 'acme' } }
+    );
   });
 
   it('setExtraHTTPHeaders replaces the previous map and applies live', async () => {
-    const ctx = await browser.newContext({
-      extraHTTPHeaders: { 'X-Tenant': 'acme' },
-    });
     let captured: string | undefined;
-    try {
-      await ctx.route('**/login.html', (req) => {
-        captured = req.headers['x-tenant'] ?? req.headers['X-Tenant'];
-      });
-      await ctx.setExtraHTTPHeaders({ 'X-Tenant': 'globex' });
+    await withContext(
+      async (ctx) => {
+        await ctx.route('**/login.html', (req) => {
+          captured = req.headers['x-tenant'] ?? req.headers['X-Tenant'];
+        });
+        await ctx.setExtraHTTPHeaders({ 'X-Tenant': 'globex' });
 
-      const page = await ctx.newPage({ url: `${baseUrl}/login.html` });
-      await page.waitForLoadState('load');
-      expect(captured).toBe('globex');
-    } finally {
-      await ctx.close();
-    }
+        const page = await ctx.newPage({ url: `${baseUrl}/login.html` });
+        await page.waitForLoadState('load');
+        expect(captured).toBe('globex');
+      },
+      { extraHTTPHeaders: { 'X-Tenant': 'acme' } }
+    );
   });
 
   // ── addInitScript ──────────────────────────────────────────────────────
@@ -138,10 +145,9 @@ describe('BrowserContext hooks & routing (Milestone B)', () => {
   it('addInitScript runs in every page of the context, including popups', async () => {
     // QA value: flip a feature-flag flag on every page (present and
     // future) without wiring per-page calls.
-    const ctx = await browser.newContext();
-    try {
+    await withContext(async (ctx) => {
       const handle = await ctx.addInitScript(`window.__E2E__ = 'yes';`);
-      expect(typeof handle.id).toBe('string');
+      expect(handle.id).toEqual(expect.any(String));
 
       const a = await ctx.newPage({ url: `${baseUrl}/login.html` });
       await a.waitForLoadState('load');
@@ -157,9 +163,7 @@ describe('BrowserContext hooks & routing (Milestone B)', () => {
       const c = await ctx.newPage({ url: `${baseUrl}/login.html` });
       await c.waitForLoadState('load');
       expect(await c.evaluate<unknown>(`return window.__E2E__;`)).toBeUndefined();
-    } finally {
-      await ctx.close();
-    }
+    });
   });
 
   it('addInitScript does NOT leak into other contexts', async () => {
@@ -217,8 +221,7 @@ describe('BrowserContext hooks & routing (Milestone B)', () => {
   });
 
   it('unroute() removes a single registered route by id', async () => {
-    const ctx = await browser.newContext();
-    try {
+    await withContext(async (ctx) => {
       let calls = 0;
       const id = await ctx.route('**/api/users', () => {
         calls++;
@@ -232,19 +235,16 @@ describe('BrowserContext hooks & routing (Milestone B)', () => {
       const page = await ctx.newPage({ url: `${baseUrl}/network.html?bidi=true` });
       await page.waitForLoadState('load');
       await page.find('#fetch-users-btn').click();
-      await page.expect('#users-result').toBeVisible();
+      await page.expect('#users-result').toContainText('"users": []');
       const after1 = calls;
       expect(after1).toBeGreaterThan(0);
 
       await ctx.unroute(id);
       await page.find('#fetch-users-btn').click();
-      // Brief delay for the second fetch — no auto-wait here.
-      await page.expect('#users-result').toBeVisible();
+      await page.expect('#users-result').toContainText('Error:');
       // Counter must not have advanced.
       expect(calls).toBe(after1);
-    } finally {
-      await ctx.close();
-    }
+    });
   });
 
   // ── on('page') / on('close') ───────────────────────────────────────────
@@ -252,9 +252,8 @@ describe('BrowserContext hooks & routing (Milestone B)', () => {
   it("on('page') fires for new pages and popups", async () => {
     // QA value: attach a console-error listener to every tab the test
     // opens — including a window.open popup — without juggling refs.
-    const ctx = await browser.newContext();
     const seen: Page[] = [];
-    try {
+    await withContext(async (ctx) => {
       ctx.on('page', (page) => {
         seen.push(page);
       });
@@ -276,19 +275,17 @@ describe('BrowserContext hooks & routing (Milestone B)', () => {
 
       // We expect to have observed both the main page and the popup.
       expect(seen.length).toBeGreaterThanOrEqual(2);
-      expect(seen.every((p) => p.context() === ctx)).toBe(true);
-    } finally {
-      await ctx.close();
-    }
+      expect(new Set(seen.map((p) => p.context()))).toEqual(new Set([ctx]));
+    });
   });
 
   it("on('close') fires when the context is closed", async () => {
-    const ctx = await browser.newContext();
     let fired = 0;
-    ctx.on('close', () => {
-      fired++;
+    await withContext(async (ctx) => {
+      ctx.on('close', () => {
+        fired++;
+      });
     });
-    await ctx.close();
     expect(fired).toBe(1);
   });
 });

--- a/tests/browser-context-storage.test.ts
+++ b/tests/browser-context-storage.test.ts
@@ -11,13 +11,27 @@ import { describe, it, beforeAll, afterAll, expect } from 'vitest';
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-import { Browser } from '../src';
+import { Browser, type BrowserContext } from '../src';
 import { EXAMPLES_BASE_URL, BROWSER_NAME } from './utils';
+
+type NewContextOptions = Parameters<Browser['newContext']>[0];
 
 describe('BrowserContext cookies & storageState', () => {
   let browser: Browser;
   let tmpDir: string;
   const baseUrl = EXAMPLES_BASE_URL;
+
+  async function withContext<T>(
+    run: (ctx: BrowserContext) => Promise<T>,
+    options?: NewContextOptions
+  ): Promise<T> {
+    const ctx = await browser.newContext(options);
+    try {
+      return await run(ctx);
+    } finally {
+      await ctx.close();
+    }
+  }
 
   beforeAll(async () => {
     browser = await Browser.launch({ browserName: BROWSER_NAME });
@@ -32,8 +46,7 @@ describe('BrowserContext cookies & storageState', () => {
   // ── Cookies ────────────────────────────────────────────────────────────
 
   it('cookies() returns cookies set by a page in this context', async () => {
-    const ctx = await browser.newContext();
-    try {
+    await withContext(async (ctx) => {
       const page = await ctx.newPage({ url: `${baseUrl}/login.html` });
       await page.waitForLoadState('load');
       await page.find('#username').fill('alice');
@@ -45,14 +58,11 @@ describe('BrowserContext cookies & storageState', () => {
       const sid = cookies.find((c) => c.name === 'session');
       expect(sid).toBeDefined();
       expect(sid?.value).toBe('alice');
-    } finally {
-      await ctx.close();
-    }
+    });
   });
 
   it('cookies(urls) filters to cookies sendable to the given URL', async () => {
-    const ctx = await browser.newContext();
-    try {
+    await withContext(async (ctx) => {
       const page = await ctx.newPage({ url: `${baseUrl}/login.html` });
       await page.waitForLoadState('load');
       await page.find('#username').fill('alice');
@@ -62,50 +72,39 @@ describe('BrowserContext cookies & storageState', () => {
 
       // First-party host returns the session cookie.
       const local = await ctx.cookies(baseUrl);
-      expect(local.some((c) => c.name === 'session')).toBe(true);
+      expect(local.map((c) => c.name)).toContain('session');
 
       // An unrelated host returns nothing.
       const other = await ctx.cookies('https://tracker.example.com/');
-      expect(other.some((c) => c.name === 'session')).toBe(false);
-    } finally {
-      await ctx.close();
-    }
+      expect(other.map((c) => c.name)).not.toContain('session');
+    });
   });
 
   it('addCookies() pre-seeds a session before the first navigation', async () => {
     // The auth-fixture shortcut: skip the login form by injecting the
     // session cookie directly, then load the page and assert we are in.
-    const ctx = await browser.newContext();
-    try {
+    await withContext(async (ctx) => {
       const hostname = new URL(baseUrl).hostname;
-      await ctx.addCookies([
-        { name: 'session', value: 'alice', domain: hostname, path: '/' },
-      ]);
+      await ctx.addCookies([{ name: 'session', value: 'alice', domain: hostname, path: '/' }]);
       const page = await ctx.newPage({ url: `${baseUrl}/login.html` });
       await page.waitForLoadState('load');
       // The page restores the session from the cookie on load.
       await page.expect('#welcome').toContainText('alice');
-    } finally {
-      await ctx.close();
-    }
+    });
   });
 
   it('addCookies() rejects sameSite:none without secure:true', async () => {
-    const ctx = await browser.newContext();
-    try {
+    await withContext(async (ctx) => {
       await expect(
         ctx.addCookies([
           { name: 'x', value: '1', domain: 'example.com', sameSite: 'none', secure: false },
         ])
       ).rejects.toThrow(/sameSite/);
-    } finally {
-      await ctx.close();
-    }
+    });
   });
 
   it('clearCookies({ name }) signs the user out without touching other cookies', async () => {
-    const ctx = await browser.newContext();
-    try {
+    await withContext(async (ctx) => {
       const hostname = new URL(baseUrl).hostname;
       await ctx.addCookies([
         { name: 'session', value: 'alice', domain: hostname, path: '/' },
@@ -115,16 +114,13 @@ describe('BrowserContext cookies & storageState', () => {
       await ctx.clearCookies({ name: 'session' });
 
       const remaining = await ctx.cookies();
-      expect(remaining.some((c) => c.name === 'session')).toBe(false);
-      expect(remaining.some((c) => c.name === 'theme')).toBe(true);
-    } finally {
-      await ctx.close();
-    }
+      expect(remaining.map((c) => c.name)).not.toContain('session');
+      expect(remaining.map((c) => c.name)).toContain('theme');
+    });
   });
 
   it('clearCookies() with no filter wipes every cookie in the context', async () => {
-    const ctx = await browser.newContext();
-    try {
+    await withContext(async (ctx) => {
       const hostname = new URL(baseUrl).hostname;
       await ctx.addCookies([
         { name: 'a', value: '1', domain: hostname, path: '/' },
@@ -134,9 +130,7 @@ describe('BrowserContext cookies & storageState', () => {
 
       await ctx.clearCookies();
       expect(await ctx.cookies()).toEqual([]);
-    } finally {
-      await ctx.close();
-    }
+    });
   });
 
   // ── storageState round-trip (the auth-fixture pattern) ─────────────────
@@ -144,41 +138,38 @@ describe('BrowserContext cookies & storageState', () => {
   it('saveStorageState() + newContext({ storageState }) skips the login UI', async () => {
     // Step 1 (the "auth fixture", normally a one-time setup):
     //   log in for real, then snapshot cookies + localStorage to disk.
-    const setupCtx = await browser.newContext();
-    const setupPage = await setupCtx.newPage({ url: `${baseUrl}/login.html` });
-    await setupPage.waitForLoadState('load');
-    await setupPage.find('#username').fill('alice');
-    await setupPage.find('#password').fill('secret');
-    await setupPage.find('#submit').click();
-    await setupPage.expect('#welcome').toContainText('alice');
-
     const statePath = path.join(tmpDir, 'alice.json');
-    const state = await setupCtx.saveStorageState(statePath);
-    expect(state.cookies?.some((c) => c.name === 'session')).toBe(true);
-    expect(state.localStorage?.[new URL(baseUrl).origin]?.theme).toBe('dark');
-    await setupCtx.close();
+    await withContext(async (setupCtx) => {
+      const setupPage = await setupCtx.newPage({ url: `${baseUrl}/login.html` });
+      await setupPage.waitForLoadState('load');
+      await setupPage.find('#username').fill('alice');
+      await setupPage.find('#password').fill('secret');
+      await setupPage.find('#submit').click();
+      await setupPage.expect('#welcome').toContainText('alice');
+
+      const state = await setupCtx.saveStorageState(statePath);
+      expect(state.cookies?.map((c) => c.name)).toContain('session');
+      expect(state.localStorage?.[new URL(baseUrl).origin]?.theme).toBe('dark');
+    });
 
     // Step 2 (every test from here on):
     //   load the snapshot — the form is already gone on first paint.
-    const ctx = await browser.newContext({ storageState: statePath });
-    try {
-      const page = await ctx.newPage({ url: `${baseUrl}/login.html` });
-      await page.waitForLoadState('load');
-      await page.expect('#welcome').toContainText('alice');
+    await withContext(
+      async (ctx) => {
+        const page = await ctx.newPage({ url: `${baseUrl}/login.html` });
+        await page.waitForLoadState('load');
+        await page.expect('#welcome').toContainText('alice');
 
-      // localStorage was restored before page scripts ran.
-      const theme = await page.evaluate<string | null>(
-        `return localStorage.getItem('theme');`
-      );
-      expect(theme).toBe('dark');
-    } finally {
-      await ctx.close();
-    }
+        // localStorage was restored before page scripts ran.
+        const theme = await page.evaluate<string | null>(`return localStorage.getItem('theme');`);
+        expect(theme).toBe('dark');
+      },
+      { storageState: statePath }
+    );
   });
 
   it('loadStorageState() replaces (does not stack) prior preload scripts', async () => {
-    const ctx = await browser.newContext();
-    try {
+    await withContext(async (ctx) => {
       const origin = new URL(baseUrl).origin;
       await ctx.loadStorageState({
         localStorage: { [origin]: { mode: 'first' } },
@@ -189,24 +180,17 @@ describe('BrowserContext cookies & storageState', () => {
 
       const page = await ctx.newPage({ url: `${baseUrl}/login.html` });
       await page.waitForLoadState('load');
-      const mode = await page.evaluate<string | null>(
-        `return localStorage.getItem('mode');`
-      );
+      const mode = await page.evaluate<string | null>(`return localStorage.getItem('mode');`);
       // Second call wins — first preload was removed.
       expect(mode).toBe('second');
-    } finally {
-      await ctx.close();
-    }
+    });
   });
 
   it('storageState() snapshot is empty for a brand-new context', async () => {
-    const ctx = await browser.newContext();
-    try {
+    await withContext(async (ctx) => {
       const state = await ctx.storageState();
       expect(state.cookies ?? []).toEqual([]);
       expect(state.localStorage ?? {}).toEqual({});
-    } finally {
-      await ctx.close();
-    }
+    });
   });
 });

--- a/tests/browser-context.test.ts
+++ b/tests/browser-context.test.ts
@@ -6,6 +6,15 @@ describe('BrowserContext (BiDi user contexts)', () => {
   let browser: Browser;
   const baseUrl = EXAMPLES_BASE_URL;
 
+  async function withContext<T>(run: (ctx: BrowserContext) => Promise<T>): Promise<T> {
+    const ctx = await browser.newContext();
+    try {
+      return await run(ctx);
+    } finally {
+      await ctx.close();
+    }
+  }
+
   beforeAll(async () => {
     browser = await Browser.launch({ browserName: BROWSER_NAME });
   });
@@ -23,34 +32,28 @@ describe('BrowserContext (BiDi user contexts)', () => {
   it('contexts() always includes the default context', async () => {
     const ctxs = await browser.contexts();
     expect(ctxs.length).toBeGreaterThanOrEqual(1);
-    expect(ctxs.some((c) => c.id === 'default')).toBe(true);
+    expect(ctxs.map((c) => c.id)).toContain('default');
   });
 
   it('newContext() creates an isolated context with a new id', async () => {
-    const ctx = await browser.newContext();
-    try {
+    await withContext(async (ctx) => {
       expect(ctx).toBeInstanceOf(BrowserContext);
       expect(ctx.id).not.toBe('default');
       const all = await browser.contexts();
-      expect(all.some((c) => c.id === ctx.id)).toBe(true);
-    } finally {
-      await ctx.close();
-    }
+      expect(all.map((c) => c.id)).toContain(ctx.id);
+    });
   });
 
   it('newPage() opens a page bound to the context', async () => {
-    const ctx = await browser.newContext();
-    try {
+    await withContext(async (ctx) => {
       const page = await ctx.newPage({ url: `${baseUrl}/login.html` });
       expect(page).toBeInstanceOf(Page);
       await page.waitForLoadState('load');
       expect(await page.title()).toContain('Login');
 
       const pages = await ctx.pages();
-      expect(pages.some((p) => p.id() === page.id())).toBe(true);
-    } finally {
-      await ctx.close();
-    }
+      expect(pages.map((p) => p.id())).toContain(page.id());
+    });
   });
 
   it('two contexts isolate cookies (multi-user login)', async () => {
@@ -84,35 +87,29 @@ describe('BrowserContext (BiDi user contexts)', () => {
     }
   });
 
-  it('page.findAll() handles stay bound to a non-default context\'s window', async () => {
+  it("page.findAll() handles stay bound to a non-default context's window", async () => {
     // Regression: findAll() used to return snapshot handles with no context
     // switcher, so a later .text() call ran against whichever window
     // happened to have Classic focus by then instead of this page's own
     // window — invisible on the always-default-context happy path, real
     // once a page lives in a non-default BrowserContext.
-    const ctx = await browser.newContext();
-    try {
+    await withContext(async (ctx) => {
       const page = await ctx.newPage({ url: `${baseUrl}/locator.html` });
       const handles = await page.findAll('.product-name');
       expect(handles.length).toBe(5);
       const texts = await Promise.all(handles.map((h) => h.text()));
       expect(texts).toContain('Widget Lite');
-    } finally {
-      await ctx.close();
-    }
+    });
   });
 
-  it('page.locator(...).all() handles stay bound to a non-default context\'s window', async () => {
-    const ctx = await browser.newContext();
-    try {
+  it("page.locator(...).all() handles stay bound to a non-default context's window", async () => {
+    await withContext(async (ctx) => {
       const page = await ctx.newPage({ url: `${baseUrl}/locator.html` });
       const handles = await page.locator('.product').filter({ hasText: 'Gadget' }).all();
       expect(handles.length).toBe(2);
       const texts = await Promise.all(handles.map((h) => h.text()));
-      expect(texts.every((t) => t.includes('Gadget'))).toBe(true);
-    } finally {
-      await ctx.close();
-    }
+      expect(texts).toEqual([expect.stringContaining('Gadget'), expect.stringContaining('Gadget')]);
+    });
   });
 
   it('close() removes the context and subsequent ops throw', async () => {
@@ -122,7 +119,7 @@ describe('BrowserContext (BiDi user contexts)', () => {
     await expect(ctx.newPage()).rejects.toThrow(/closed/);
 
     const all = await browser.contexts();
-    expect(all.some((c) => c.id === ctx.id)).toBe(false);
+    expect(all.map((c) => c.id)).not.toContain(ctx.id);
   });
 
   it('defaultContext.close() throws (cannot remove default)', async () => {

--- a/tests/chromedriver-cache.test.ts
+++ b/tests/chromedriver-cache.test.ts
@@ -31,7 +31,7 @@ class FakeChromeService extends ChromeService {
 
   constructor(
     private readonly staleDriverPath: string,
-    private readonly freshDriverPath: string,
+    private readonly freshDriverPath: string
   ) {
     super();
   }
@@ -72,10 +72,13 @@ class FakeChromeService extends ChromeService {
       writeJson(res, 404, { value: { error: 'unknown command', message: req.url } });
     });
 
-    await new Promise<void>((resolve) => {
+    await new Promise<void>((resolve, reject) => {
       this.server!.listen(0, '127.0.0.1', () => {
         const address = this.server!.address();
-        if (typeof address !== 'object' || !address) throw new Error('No fake service port');
+        if (typeof address !== 'object' || !address) {
+          reject(new Error('No fake service port'));
+          return;
+        }
         this.endpoint = {
           protocol: 'http',
           hostname: '127.0.0.1',
@@ -130,21 +133,20 @@ describe('chromedriver auto-resolution cache recovery', () => {
           driverPath: staleDriverPath,
           timestamp: Date.now(),
         },
-      }),
+      })
     );
 
     const service = new FakeChromeService(staleDriverPath, freshDriverPath);
     let driver: Driver | undefined;
     try {
-      driver = await new Builder()
-        .forBrowser('chrome')
-        .setChromeService(service)
-        .build();
+      driver = await new Builder().forBrowser('chrome').setChromeService(service).build();
 
       expect(service.startCalls).toBe(2);
       expect(service.stopCalls).toBe(1);
-      expect(JSON.parse(fs.readFileSync(path.join(cacheDir, 'metadata.json'), 'utf-8'))[cacheKey])
-        .toBeUndefined();
+      const metadata = JSON.parse(
+        fs.readFileSync(path.join(cacheDir, 'metadata.json'), 'utf-8')
+      ) as Record<string, unknown>;
+      expect(metadata[cacheKey]).toBeUndefined();
     } finally {
       await driver?.quit();
       await service.stop();

--- a/tests/cli-smoke.test.ts
+++ b/tests/cli-smoke.test.ts
@@ -28,6 +28,14 @@ interface RunResult {
   lines: Array<{ ok: boolean; result?: unknown; error?: { code: string; message: string } }>;
 }
 
+function parseOutputLine(line: string): RunResult['lines'][number] {
+  try {
+    return JSON.parse(line) as RunResult['lines'][number];
+  } catch {
+    return { ok: false, error: { code: 'PARSE_ERROR', message: line } };
+  }
+}
+
 /**
  * Spawn `craftdriver --ephemeral` and feed a script via stdin.
  * stdout is piped (not a TTY) so the CLI emits one JSON object per
@@ -35,14 +43,10 @@ interface RunResult {
  */
 async function runCli(script: string): Promise<RunResult> {
   return new Promise((resolveRun, reject) => {
-    const child = spawn(
-      'node',
-      [CLI_BIN, '--ephemeral', '--browser', BROWSER_NAME],
-      {
-        env: { ...process.env, HEADLESS: 'true' },
-        stdio: ['pipe', 'pipe', 'pipe'],
-      },
-    );
+    const child = spawn('node', [CLI_BIN, '--ephemeral', '--browser', BROWSER_NAME], {
+      env: { ...process.env, HEADLESS: 'true' },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
 
     let stdout = '';
     let stderr = '';
@@ -54,13 +58,7 @@ async function runCli(script: string): Promise<RunResult> {
         .split('\n')
         .map((l) => l.trim())
         .filter((l) => l.length > 0)
-        .map((l) => {
-          try {
-            return JSON.parse(l) as RunResult['lines'][number];
-          } catch {
-            return { ok: false, error: { code: 'PARSE_ERROR', message: l } };
-          }
-        });
+        .map(parseOutputLine);
       resolveRun({ exitCode: code ?? -1, stdout, stderr, lines });
     });
 
@@ -86,11 +84,11 @@ describe('CLI smoke', () => {
     expect(run.exitCode, run.stderr).toBe(0);
     // One JSON line per command — 5 commands.
     expect(run.lines).toHaveLength(5);
-    expect(run.lines.every((l) => l.ok)).toBe(true);
+    expect(run.lines.map((line) => line.ok)).toEqual([true, true, true, true, true]);
 
-    const last = run.lines[4];
-    const result = last.result as { text: string };
-    expect(result.text).toContain('Welcome back, testuser!');
+    expect(run.lines.at(-1)?.result).toMatchObject({
+      text: expect.stringContaining('Welcome back, testuser!'),
+    });
   });
 
   it('takes a snapshot listing the form controls with refs', async () => {
@@ -99,7 +97,7 @@ describe('CLI smoke', () => {
 
     expect(run.exitCode, run.stderr).toBe(0);
     expect(run.lines).toHaveLength(2);
-    expect(run.lines.every((l) => l.ok)).toBe(true);
+    expect(run.lines.map((line) => line.ok)).toEqual([true, true]);
 
     const snap = run.lines[1].result as { url: string; lines: string[] };
     expect(snap.url).toContain('/login.html');
@@ -127,10 +125,10 @@ describe('CLI smoke', () => {
     expect(run.lines).toHaveLength(4);
 
     expect(run.lines[1].ok).toBe(true);
-    expect((run.lines[1].result as { exists: boolean }).exists).toBe(true);
+    expect(run.lines[1].result).toMatchObject({ exists: true });
 
     expect(run.lines[2].ok).toBe(true);
-    expect((run.lines[2].result as { exists: boolean }).exists).toBe(false);
+    expect(run.lines[2].result).toMatchObject({ exists: false });
 
     expect(run.lines[3].ok).toBe(false);
     expect(run.lines[3].error?.code).toBe('NO_MATCH');

--- a/tests/clock.test.ts
+++ b/tests/clock.test.ts
@@ -36,7 +36,9 @@ describe('browser.clock', () => {
     await browser.clock.install({ time: 0 });
     await browser.evaluate(() => {
       (window as any).__fired = false;
-      setTimeout(() => { (window as any).__fired = true; }, 500);
+      setTimeout(() => {
+        (window as any).__fired = true;
+      }, 500);
     });
 
     await browser.clock.tick(499);
@@ -52,7 +54,9 @@ describe('browser.clock', () => {
     await browser.clock.install({ time: 0 });
     await browser.evaluate(() => {
       (window as any).__count = 0;
-      (window as any).__id = setInterval(() => { (window as any).__count++; }, 100);
+      (window as any).__id = setInterval(() => {
+        (window as any).__count++;
+      }, 100);
     });
 
     await browser.clock.tick(500);
@@ -69,8 +73,12 @@ describe('browser.clock', () => {
     await browser.evaluate(() => {
       (window as any).__zero = false;
       (window as any).__cancelled = false;
-      setTimeout(() => { (window as any).__zero = true; }, 0);
-      const id = setTimeout(() => { (window as any).__cancelled = true; }, 0);
+      setTimeout(() => {
+        (window as any).__zero = true;
+      }, 0);
+      const id = setTimeout(() => {
+        (window as any).__cancelled = true;
+      }, 0);
       clearTimeout(id);
     });
 
@@ -84,9 +92,11 @@ describe('browser.clock', () => {
     await browser.clock.install();
     await browser.navigateTo(CLOCK_URL); // preload applies on this nav
     await browser.clock.fastForward('15:01');
-    expect(await browser.evaluate(() =>
-      document.getElementById('login-modal')!.classList.contains('visible')
-    )).toBe(true);
+    expect(
+      await browser.evaluate(() =>
+        document.getElementById('login-modal')!.classList.contains('visible')
+      )
+    ).toBe(true);
 
     // HH:MM:SS — re-install to reset, then verify the three-part parser
     await browser.clock.install({ time: 0 });
@@ -118,16 +128,16 @@ describe('browser.clock', () => {
     // One minute before — banner shows "expires today"
     await browser.clock.setFixedTime('2026-06-15T23:59:00Z');
     await browser.navigateTo(CLOCK_URL);
-    expect(await browser.evaluate(() =>
-      document.getElementById('trial-banner')!.textContent
-    )).toContain('expires today');
+    expect(
+      await browser.evaluate(() => document.getElementById('trial-banner')!.textContent)
+    ).toContain('expires today');
 
     // One second after — banner shows "expired"
     await browser.clock.setFixedTime('2026-06-16T00:00:01Z');
     await browser.navigateTo(CLOCK_URL);
-    expect(await browser.evaluate(() =>
-      document.getElementById('trial-banner')!.textContent
-    )).toContain('expired');
+    expect(
+      await browser.evaluate(() => document.getElementById('trial-banner')!.textContent)
+    ).toContain('expired');
   });
 
   it('setFixedTime() preload survives navigations', async () => {
@@ -145,7 +155,9 @@ describe('browser.clock', () => {
     await browser.clock.install({ time: 0 });
     await browser.evaluate(() => {
       (window as any).__count = 0;
-      setInterval(() => { (window as any).__count++; }, 100);
+      setInterval(() => {
+        (window as any).__count++;
+      }, 100);
     });
 
     // Jump ahead — no timers should fire during the jump
@@ -163,7 +175,9 @@ describe('browser.clock', () => {
     await browser.evaluate(() => {
       (window as any).__done = false;
       setTimeout(() => {
-        Promise.resolve().then(() => { (window as any).__done = true; });
+        Promise.resolve().then(() => {
+          (window as any).__done = true;
+        });
       }, 50);
     });
 
@@ -178,14 +192,18 @@ describe('browser.clock', () => {
     await browser.fill('#search-input', 'lap');
 
     await browser.clock.tick(299); // just before the 300 ms debounce
-    expect(await browser.evaluate(() =>
-      parseInt(document.getElementById('search-count')!.textContent || '0', 10)
-    )).toBe(0);
+    expect(
+      await browser.evaluate(() =>
+        parseInt(document.getElementById('search-count')!.textContent || '0', 10)
+      )
+    ).toBe(0);
 
     await browser.clock.tick(2); // total 301 ms — debounce fires once
-    expect(await browser.evaluate(() =>
-      parseInt(document.getElementById('search-count')!.textContent || '0', 10)
-    )).toBe(1);
+    expect(
+      await browser.evaluate(() =>
+        parseInt(document.getElementById('search-count')!.textContent || '0', 10)
+      )
+    ).toBe(1);
   });
 
   it('install() preload survives navigation; re-install resets the virtual time', async () => {
@@ -215,4 +233,3 @@ describe('browser.clock', () => {
     expect(await browser.evaluate(() => Date.now())).toBeGreaterThan(1_000_000_000_000);
   });
 });
-

--- a/tests/dialogs.test.ts
+++ b/tests/dialogs.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, beforeAll, afterAll, beforeEach, expect } from 'vitest';
-import { Browser } from '../src';
+import { Browser, type Dialog } from '../src';
 import { EXAMPLES_BASE_URL, BROWSER_NAME } from './utils';
 
 describe('Dialog handling (alert / confirm / prompt)', () => {
@@ -17,13 +17,15 @@ describe('Dialog handling (alert / confirm / prompt)', () => {
     await browser.navigateTo(`${EXAMPLES_BASE_URL}/dialogs.html`);
   });
 
+  async function clickAndWaitForDialog(selector: string): Promise<Dialog> {
+    const [, dialog] = await Promise.all([browser.click(selector), browser.waitForDialog()]);
+    return dialog;
+  }
+
   // ── alert ──────────────────────────────────────────────────────────────────
 
   it('accepts an alert', async () => {
-    const [, dialog] = await Promise.all([
-      browser.click('#show-alert'),
-      browser.waitForDialog(),
-    ]);
+    const dialog = await clickAndWaitForDialog('#show-alert');
     expect(dialog.type()).toBe('alert');
     expect(dialog.message()).toBe('Hello from alert');
     await dialog.accept();
@@ -32,10 +34,7 @@ describe('Dialog handling (alert / confirm / prompt)', () => {
   });
 
   it('dismisses an alert', async () => {
-    const [, dialog] = await Promise.all([
-      browser.click('#show-alert'),
-      browser.waitForDialog(),
-    ]);
+    const dialog = await clickAndWaitForDialog('#show-alert');
     await dialog.dismiss();
     await browser.expect('h1').toHaveText('Dialogs');
   });
@@ -43,10 +42,7 @@ describe('Dialog handling (alert / confirm / prompt)', () => {
   // ── confirm ────────────────────────────────────────────────────────────────
 
   it('accepting a confirm records "confirmed" on the page', async () => {
-    const [, dialog] = await Promise.all([
-      browser.click('#show-confirm'),
-      browser.waitForDialog(),
-    ]);
+    const dialog = await clickAndWaitForDialog('#show-confirm');
     expect(dialog.type()).toBe('confirm');
     expect(dialog.message()).toBe('Are you sure?');
     await dialog.accept();
@@ -54,10 +50,7 @@ describe('Dialog handling (alert / confirm / prompt)', () => {
   });
 
   it('dismissing a confirm records "dismissed" on the page', async () => {
-    const [, dialog] = await Promise.all([
-      browser.click('#show-confirm'),
-      browser.waitForDialog(),
-    ]);
+    const dialog = await clickAndWaitForDialog('#show-confirm');
     await dialog.dismiss();
     await browser.expect('#confirm-result').toHaveText('dismissed');
   });
@@ -65,10 +58,7 @@ describe('Dialog handling (alert / confirm / prompt)', () => {
   // ── prompt ─────────────────────────────────────────────────────────────────
 
   it('accepting a prompt with text echoes the value on the page', async () => {
-    const [, dialog] = await Promise.all([
-      browser.click('#show-prompt'),
-      browser.waitForDialog(),
-    ]);
+    const dialog = await clickAndWaitForDialog('#show-prompt');
     expect(dialog.type()).toBe('prompt');
     expect(dialog.defaultValue()).toBe('default');
     await dialog.accept('craftdriver');
@@ -76,10 +66,7 @@ describe('Dialog handling (alert / confirm / prompt)', () => {
   });
 
   it('dismissing a prompt echoes "dismissed" on the page', async () => {
-    const [, dialog] = await Promise.all([
-      browser.click('#show-prompt'),
-      browser.waitForDialog(),
-    ]);
+    const dialog = await clickAndWaitForDialog('#show-prompt');
     await dialog.dismiss();
     await browser.expect('#prompt-result').toHaveText('dismissed');
   });
@@ -88,18 +75,23 @@ describe('Dialog handling (alert / confirm / prompt)', () => {
 
   it('onDialog registers a persistent handler', async () => {
     let capturedMessage = '';
-    let handlerDone: () => void;
-    const handled = new Promise<void>(r => { handlerDone = r; });
+    let resolveHandled!: () => void;
+    const handled = new Promise<void>((resolve) => {
+      resolveHandled = resolve;
+    });
 
     const off = browser.onDialog(async (dialog) => {
       capturedMessage = dialog.message();
       await dialog.accept();
-      handlerDone();
+      resolveHandled();
     });
 
-    await browser.click('#show-alert');
-    await handled;
-    off();
+    try {
+      await browser.click('#show-alert');
+      await handled;
+    } finally {
+      off();
+    }
 
     expect(capturedMessage).toBe('Hello from alert');
   });
@@ -107,13 +99,9 @@ describe('Dialog handling (alert / confirm / prompt)', () => {
   // ── imperative API ─────────────────────────────────────────────────────────
 
   it('acceptDialog() imperative form works without onDialog', async () => {
-    const [, dialog] = await Promise.all([
-      browser.click('#show-alert'),
-      browser.waitForDialog(),
-    ]);
+    await clickAndWaitForDialog('#show-alert');
     // Use imperative API directly
     await browser.acceptDialog();
-    void dialog; // dialog is available if needed
     await browser.expect('h1').toHaveText('Dialogs');
   });
 });

--- a/tests/download.test.ts
+++ b/tests/download.test.ts
@@ -20,12 +20,11 @@ describe('File download — waitForDownload()', () => {
 
   afterAll(async () => {
     await browser.quit();
+    fs.rmSync(downloadsDir, { recursive: true, force: true });
   });
 
   it('resolves with a Download whose path exists on disk', async () => {
-    const dl = await browser.waitForDownload(
-      () => browser.click('#download-btn')
-    );
+    const dl = await browser.waitForDownload(() => browser.click('#download-btn'));
 
     expect(dl.suggestedFilename).toBe('report.txt');
     expect(fs.existsSync(dl.path)).toBe(true);
@@ -34,16 +33,17 @@ describe('File download — waitForDownload()', () => {
   it('saveAs() copies the file to the given target', async () => {
     const target = path.join(os.tmpdir(), `craftdriver-copy-${Date.now()}.txt`);
 
-    const dl = await browser.waitForDownload(
-      () => browser.click('#download-btn'),
-      { timeout: 15000 }
-    );
+    const dl = await browser.waitForDownload(() => browser.click('#download-btn'), {
+      timeout: 15000,
+    });
 
-    await dl.saveAs(target);
-    expect(fs.existsSync(target)).toBe(true);
-    expect(fs.readFileSync(target, 'utf8')).toContain('craftdriver download test');
-
-    fs.rmSync(target);
+    try {
+      await dl.saveAs(target);
+      expect(fs.existsSync(target)).toBe(true);
+      expect(fs.readFileSync(target, 'utf8')).toContain('craftdriver download test');
+    } finally {
+      fs.rmSync(target, { force: true });
+    }
   });
 
   it('timeout rejects with a clear message', async () => {

--- a/tests/driver-manager.test.ts
+++ b/tests/driver-manager.test.ts
@@ -42,7 +42,7 @@ describe('driver manager — auto-download integration', () => {
   const testCacheDir = path.join(os.tmpdir(), `craftdriver-test-cache-${process.pid}`);
 
   let browser: Browser | undefined;
-  let restoreEnv: () => void;
+  let restoreEnv = () => {};
 
   beforeAll(async () => {
     // Ensure the test cache starts empty so we exercise the download path.
@@ -100,14 +100,15 @@ describe('driver manager — auto-download integration', () => {
     if (os.platform() !== 'win32') {
       const mode = fs.statSync(driverBin).mode;
       // Check owner-execute bit (0o100)
-      expect(mode & 0o100).toBeTruthy();
+      expect(mode & 0o100).toBe(0o100);
     }
   });
 
   it('starts the browser and can navigate to a page', async () => {
     expect(browser).toBeDefined();
-    await browser!.navigateTo('about:blank');
-    const url = await browser!.url();
+    const launchedBrowser = browser!;
+    await launchedBrowser.navigateTo('about:blank');
+    const url = await launchedBrowser.url();
     expect(url).toBe('about:blank');
   });
 });

--- a/tests/element-handle.test.ts
+++ b/tests/element-handle.test.ts
@@ -97,10 +97,9 @@ describe('ElementHandle API', () => {
 
     it('hovers an element scrolled below the fold', async () => {
       // Push the tooltip trigger far below the viewport, then hover it without
-      // scrolling manually. Regression guard for the pointer-move origin: moving
-      // to the element origin scrolls it into view and lands on its in-view
-      // centre, whereas computing the centre from document-relative getRect() and
-      // moving in viewport space misses a scrolled-out element (out of bounds).
+      // scrolling manually. Chrome scrolls element-origin Actions moves into
+      // view, but geckodriver may reject them as out of bounds; pointerMoveTo()
+      // should handle that by scrolling the element into view and retrying.
       await browser.evaluate(() => {
         const spacer = document.createElement('div');
         spacer.style.height = '2500px';

--- a/tests/element-handle.test.ts
+++ b/tests/element-handle.test.ts
@@ -32,6 +32,34 @@ describe('ElementHandle API', () => {
     });
   });
 
+  describe('click()', () => {
+    beforeEach(async () => {
+      await browser.navigateTo(`${baseUrl}/login.html`);
+    });
+
+    it('clicks an element scrolled below the fold', async () => {
+      await browser.evaluate(() => {
+        const spacer = document.createElement('div');
+        const button = document.createElement('button');
+        const status = document.createElement('div');
+        spacer.style.height = '2500px';
+        button.id = 'below-fold-click-target';
+        button.textContent = 'Click below fold';
+        status.id = 'below-fold-click-status';
+        status.textContent = 'Not clicked';
+        button.addEventListener('click', () => {
+          status.textContent = 'Clicked below fold';
+        });
+        document.body.insertBefore(spacer, document.body.firstChild);
+        spacer.after(button, status);
+        window.scrollTo(0, 0);
+      });
+
+      await browser.find('#below-fold-click-target').click();
+      await browser.expect('#below-fold-click-status').toContainText('Clicked below fold');
+    });
+  });
+
   describe('text(), value(), tagName(), getAttribute()', () => {
     beforeEach(async () => {
       await browser.navigateTo(`${baseUrl}/login.html`);
@@ -39,23 +67,23 @@ describe('ElementHandle API', () => {
 
     it('text() returns element text content', async () => {
       const heading = await browser.find('h1').text();
-      if (!heading.includes('Login')) throw new Error(`Expected heading to contain "Login"`);
+      expect(heading).toContain('Login');
     });
 
     it('value() returns input value', async () => {
       await browser.find('#username').fill('test123');
       const val = await browser.find('#username').value();
-      if (val !== 'test123') throw new Error(`Expected "test123" but got "${val}"`);
+      expect(val).toBe('test123');
     });
 
     it('tagName() returns element tag name', async () => {
       const tag = await browser.find('h1').tagName();
-      if (tag !== 'h1') throw new Error(`Expected "h1" but got "${tag}"`);
+      expect(tag).toBe('h1');
     });
 
     it('getAttribute() returns attribute value', async () => {
       const attr = await browser.find('#password').getAttribute('type');
-      if (attr !== 'password') throw new Error(`Expected "password" but got "${attr}"`);
+      expect(attr).toBe('password');
     });
   });
 
@@ -66,12 +94,12 @@ describe('ElementHandle API', () => {
 
     it('isVisible() returns true for visible elements', async () => {
       const visible = await browser.find('#username').isVisible();
-      if (!visible) throw new Error('Expected element to be visible');
+      expect(visible).toBe(true);
     });
 
     it('isEnabled() returns true for enabled inputs', async () => {
       const enabled = await browser.find('#username').isEnabled();
-      if (!enabled) throw new Error('Expected element to be enabled');
+      expect(enabled).toBe(true);
     });
   });
 
@@ -79,9 +107,9 @@ describe('ElementHandle API', () => {
     it('returns element dimensions', async () => {
       await browser.navigateTo(`${baseUrl}/login.html`);
       const box = await browser.find('#username').boundingBox();
-      if (!box || box.width <= 0 || box.height <= 0) {
-        throw new Error('Expected bounding box with positive dimensions');
-      }
+      expect(box).not.toBeNull();
+      expect(box!.width).toBeGreaterThan(0);
+      expect(box!.height).toBeGreaterThan(0);
     });
   });
 
@@ -120,31 +148,14 @@ describe('ElementHandle API', () => {
     it('selects option from dropdown', async () => {
       await browser.find('#language-select').select('es');
 
-      const value = await browser.getValue('#language-select');
-      if (value !== 'es') {
-        throw new Error(`Expected language to be "es" but got "${value}"`);
-      }
-
+      await browser.expect('#language-select').toHaveValue('es');
       await browser.expect('#select-result').toContainText('Language: es');
     });
 
     it('throws error when using select on non-select element', async () => {
-      let errorThrown = false;
-      try {
-        await browser.find('#tooltip-trigger').select('invalid');
-      } catch (error: any) {
-        errorThrown = true;
-        if (!error.message.includes('can only be used on <select> elements')) {
-          throw new Error(`Expected specific error message but got: ${error.message}`);
-        }
-        if (!error.message.includes('Found <div>')) {
-          throw new Error(`Expected error to mention element type but got: ${error.message}`);
-        }
-      }
-
-      if (!errorThrown) {
-        throw new Error('Expected select() to throw error on non-select element');
-      }
+      await expect(browser.find('#tooltip-trigger').select('invalid')).rejects.toThrow(
+        /select\(\) can only be used on <select> elements\. Found <div> instead\./
+      );
     });
   });
 
@@ -270,11 +281,11 @@ describe('Browser-level element methods', () => {
   it('getValue() returns input value', async () => {
     await browser.fill('#username', 'myvalue');
     const val = await browser.getValue('#username');
-    if (val !== 'myvalue') throw new Error(`Expected "myvalue" but got "${val}"`);
+    expect(val).toBe('myvalue');
   });
 
   it('getAttribute() returns element attribute', async () => {
     const typeAttr = await browser.getAttribute('#username', 'type');
-    if (typeAttr !== 'text') throw new Error(`Expected "text" but got "${typeAttr}"`);
+    expect(typeAttr).toBe('text');
   });
 });

--- a/tests/element-handle.test.ts
+++ b/tests/element-handle.test.ts
@@ -94,6 +94,23 @@ describe('ElementHandle API', () => {
       await browser.find('#tooltip-trigger').hover();
       await browser.expect('#tooltip-status').toContainText('Tooltip is visible');
     });
+
+    it('hovers an element scrolled below the fold', async () => {
+      // Push the tooltip trigger far below the viewport, then hover it without
+      // scrolling manually. Regression guard for the pointer-move origin: moving
+      // to the element origin scrolls it into view and lands on its in-view
+      // centre, whereas computing the centre from document-relative getRect() and
+      // moving in viewport space misses a scrolled-out element (out of bounds).
+      await browser.evaluate(() => {
+        const spacer = document.createElement('div');
+        spacer.style.height = '2500px';
+        document.body.insertBefore(spacer, document.body.firstChild);
+        window.scrollTo(0, 0);
+      });
+
+      await browser.find('#tooltip-trigger').hover();
+      await browser.expect('#tooltip-status').toContainText('Tooltip is visible');
+    });
   });
 
   describe('select()', () => {
@@ -209,6 +226,46 @@ describe('Browser-level element methods', () => {
     await browser.fill('#username', 'some text');
     await browser.clear('#username');
     await browser.expect('#username').toHaveValue('');
+  });
+
+  it('clear() skips the visibility wait when the input is already ready', async () => {
+    await browser.fill('#username', 'some text');
+
+    const driver = (browser as any).driver;
+    const originalWait = driver.wait.bind(driver);
+    let waitCalls = 0;
+    driver.wait = (...args: any[]) => {
+      waitCalls += 1;
+      return originalWait(...args);
+    };
+
+    try {
+      await browser.clear('#username');
+    } finally {
+      driver.wait = originalWait;
+    }
+
+    expect(waitCalls).toBe(0);
+    await browser.expect('#username').toHaveValue('');
+  });
+
+  it('clear() waits for an attached input to become visible', async () => {
+    await browser.evaluate(() => {
+      const input = document.createElement('input');
+      input.id = 'delayed-clear';
+      input.value = 'content';
+      input.style.display = 'none';
+      document.body.appendChild(input);
+      setTimeout(() => {
+        input.style.display = 'block';
+      }, 300);
+    });
+
+    const start = Date.now();
+    await browser.clear('#delayed-clear', { timeout: 3000 });
+
+    expect(Date.now() - start).toBeGreaterThanOrEqual(200);
+    await browser.expect('#delayed-clear').toHaveValue('');
   });
 
   it('getValue() returns input value', async () => {

--- a/tests/emulate.test.ts
+++ b/tests/emulate.test.ts
@@ -15,14 +15,18 @@ describe('browser.emulate()', () => {
 
   beforeEach(async () => {
     // Reset all overrides before each test so they don't leak.
-    await browser.emulate({
-      colorScheme: null,
-      reducedMotion: null,
-      forcedColors: null,
-      locale: null,
-      timezoneId: null,
-      offline: false,
-    }).catch(() => { /* Firefox may reject media/offline; ignore in reset */ });
+    await browser
+      .emulate({
+        colorScheme: null,
+        reducedMotion: null,
+        forcedColors: null,
+        locale: null,
+        timezoneId: null,
+        offline: false,
+      })
+      .catch(() => {
+        /* Firefox may reject media/offline; ignore in reset */
+      });
     await browser.navigateTo(`${EXAMPLES_BASE_URL}/emulate.html`);
   });
 
@@ -57,25 +61,32 @@ describe('browser.emulate()', () => {
     await browser.expect('#scheme-readout').toHaveText('dark');
   });
 
-  it.skipIf(!IS_CHROMIUM)('offline: true makes fetch reject and navigator.onLine false', async () => {
-    await browser.emulate({ offline: true });
-    await browser.expect('#online-readout').toHaveText('offline');
+  it.skipIf(!IS_CHROMIUM)(
+    'offline: true makes fetch reject and navigator.onLine false',
+    async () => {
+      await browser.emulate({ offline: true });
+      await browser.expect('#online-readout').toHaveText('offline');
 
-    await browser.click('#fetch-btn');
-    await browser.expect('#fetch-readout').toContainText('error');
+      await browser.click('#fetch-btn');
+      await browser.expect('#fetch-readout').toContainText('error');
 
-    // Restore so the next test's reset doesn't run while offline.
-    await browser.emulate({ offline: false });
-  });
+      // Restore so the next test's reset doesn't run while offline.
+      await browser.emulate({ offline: false });
+    }
+  );
 
   it.skipIf(IS_CHROMIUM)('throws a clear error for Chromium-only fields on Firefox', async () => {
-    await expect(browser.emulate({ colorScheme: 'dark' })).rejects.toThrow(/not supported on Firefox/);
+    await expect(browser.emulate({ colorScheme: 'dark' })).rejects.toThrow(
+      /not supported on Firefox/
+    );
   });
 
   it('throws a clear error when BiDi is disabled', async () => {
     const noBidi = await Browser.launch({ browserName: BROWSER_NAME, enableBiDi: false });
     try {
-      await expect(noBidi.emulate({ locale: 'de-DE' })).rejects.toThrow(/emulate\(\) requires BiDi/);
+      await expect(noBidi.emulate({ locale: 'de-DE' })).rejects.toThrow(
+        /emulate\(\) requires BiDi/
+      );
     } finally {
       await noBidi.quit();
     }

--- a/tests/error-codes.test.ts
+++ b/tests/error-codes.test.ts
@@ -1,6 +1,17 @@
 import { describe, it, beforeAll, afterAll, beforeEach, expect } from 'vitest';
-import { Browser, By, CraftdriverError, ErrorCode } from '../src';
+import { Browser, By, CraftdriverError, ErrorCode, type ErrorCodeValue } from '../src';
 import { EXAMPLES_BASE_URL, BROWSER_NAME } from './utils';
+
+async function expectCraftdriverError(
+  action: () => Promise<unknown>,
+  code: ErrorCodeValue
+): Promise<CraftdriverError> {
+  const err = await action().catch((e: unknown) => e);
+  expect(err).toBeInstanceOf(CraftdriverError);
+  const craftdriverError = err as CraftdriverError;
+  expect(craftdriverError.code).toBe(code);
+  return craftdriverError;
+}
 
 describe('error codes', () => {
   let browser: Browser;
@@ -19,14 +30,12 @@ describe('error codes', () => {
   });
 
   it('locator.click on a missing selector throws NO_MATCH', async () => {
-    let err: unknown;
-    try {
-      await browser.locator('#definitely-not-here').click();
-    } catch (e) {
-      err = e;
-    }
-    expect(CraftdriverError.is(err, ErrorCode.NO_MATCH)).toBe(true);
-    expect((err as CraftdriverError).detail).toMatchObject({
+    const err = await expectCraftdriverError(
+      () => browser.locator('#definitely-not-here').click(),
+      ErrorCode.NO_MATCH
+    );
+
+    expect(err.detail).toMatchObject({
       using: 'css selector',
       value: '#definitely-not-here',
     });
@@ -41,47 +50,41 @@ describe('error codes', () => {
       el.style.display = 'none';
       document.body.appendChild(el);
     });
-    let err: unknown;
-    try {
-      // Use a chained locator (not the fast simple path) so we hit
-      // _waitForVisible directly and exercise the visible-vs-no-match split.
-      await browser.locator('body').locator('#hidden-target').click();
-    } catch (e) {
-      err = e;
-    }
-    expect(CraftdriverError.is(err, ErrorCode.TIMEOUT_WAITING_VISIBLE)).toBe(true);
+
+    // Use a chained locator (not the fast simple path) so we hit
+    // _waitForVisible directly and exercise the visible-vs-no-match split.
+    await expectCraftdriverError(
+      () => browser.locator('body').locator('#hidden-target').click(),
+      ErrorCode.TIMEOUT_WAITING_VISIBLE
+    );
   });
 
   it('expect() failure throws EXPECT_MISMATCH', async () => {
-    let err: unknown;
-    try {
-      await browser.locator('h1').expect().toHaveText('this is not the heading');
-    } catch (e) {
-      err = e;
-    }
-    expect(CraftdriverError.is(err, ErrorCode.EXPECT_MISMATCH)).toBe(true);
+    await expectCraftdriverError(
+      () => browser.locator('h1').expect().toHaveText('this is not the heading'),
+      ErrorCode.EXPECT_MISMATCH
+    );
   });
 
   it('evaluate() with a non-JSON arg throws EVAL_BAD_ARG', async () => {
-    let err: unknown;
-    try {
-      await browser.evaluate((x: unknown) => x, () => 1);
-    } catch (e) {
-      err = e;
-    }
-    expect(CraftdriverError.is(err, ErrorCode.EVAL_BAD_ARG)).toBe(true);
+    await expectCraftdriverError(
+      () =>
+        browser.evaluate(
+          (x: unknown) => x,
+          () => 1
+        ),
+      ErrorCode.EVAL_BAD_ARG
+    );
   });
 
   it('evaluate() of code that throws yields EVAL_THREW', async () => {
-    let err: unknown;
-    try {
-      await browser.evaluate(() => {
-        throw new Error('boom from page');
-      });
-    } catch (e) {
-      err = e;
-    }
-    expect(CraftdriverError.is(err, ErrorCode.EVAL_THREW)).toBe(true);
+    await expectCraftdriverError(
+      () =>
+        browser.evaluate(() => {
+          throw new Error('boom from page');
+        }),
+      ErrorCode.EVAL_THREW
+    );
   });
 
   // ── Phase 0: WebDriver protocol errors surface as DRIVER_ERROR ────────────
@@ -92,15 +95,10 @@ describe('error codes', () => {
   it('clicking a snapshot handle whose element was removed throws DRIVER_ERROR (stale)', async () => {
     const [handle] = await browser.findAll('#username');
     await browser.evaluate(() => document.getElementById('username')?.remove());
-    let err: unknown;
-    try {
-      await handle.click();
-    } catch (e) {
-      err = e;
-    }
-    expect(CraftdriverError.is(err, ErrorCode.DRIVER_ERROR)).toBe(true);
-    expect(String((err as CraftdriverError).detail?.webDriverError)).toContain('stale element');
-    const stack = String((err as Error).stack);
+
+    const err = await expectCraftdriverError(() => handle.click(), ErrorCode.DRIVER_ERROR);
+    expect(String(err.detail?.webDriverError)).toContain('stale element');
+    const stack = String(err.stack);
     expect(stack).toContain('tests/error-codes.test.ts');
     expect(stack).not.toContain('src/lib/http.ts');
   });
@@ -116,14 +114,9 @@ describe('error codes', () => {
       overlay.style.zIndex = '99999';
       document.body.appendChild(overlay);
     });
-    let err: unknown;
-    try {
-      await handle.click();
-    } catch (e) {
-      err = e;
-    }
-    expect(CraftdriverError.is(err, ErrorCode.DRIVER_ERROR)).toBe(true);
-    expect(String((err as CraftdriverError).detail?.webDriverError)).toContain('intercepted');
+
+    const err = await expectCraftdriverError(() => handle.click(), ErrorCode.DRIVER_ERROR);
+    expect(String(err.detail?.webDriverError)).toContain('intercepted');
   });
 
   it('evaluate() returning error-shaped data resolves — status gating, not body shape', async () => {
@@ -134,34 +127,24 @@ describe('error codes', () => {
   });
 
   it('stopTrace() without startTrace() throws STATE_INVALID', async () => {
-    let err: unknown;
-    try {
-      await browser.stopTrace();
-    } catch (e) {
-      err = e;
-    }
-    expect(CraftdriverError.is(err, ErrorCode.STATE_INVALID)).toBe(true);
+    await expectCraftdriverError(() => browser.stopTrace(), ErrorCode.STATE_INVALID);
   });
 
   it('locator.waitFor() with a bogus state throws INVALID_ARGUMENT', async () => {
-    let err: unknown;
-    try {
-      await browser.locator('h1').waitFor({ state: 'nonsense' as never });
-    } catch (e) {
-      err = e;
-    }
-    expect(CraftdriverError.is(err, ErrorCode.INVALID_ARGUMENT)).toBe(true);
+    await expectCraftdriverError(
+      () => browser.locator('h1').waitFor({ state: 'nonsense' as never }),
+      ErrorCode.INVALID_ARGUMENT
+    );
   });
 
   it('every CraftdriverError remains instanceof Error and carries a hint where applicable', async () => {
-    let err: CraftdriverError | undefined;
-    try {
-      await browser.locator(By.css('#missing-too')).click();
-    } catch (e) {
-      err = e as CraftdriverError;
-    }
+    const err = await expectCraftdriverError(
+      () => browser.locator(By.css('#missing-too')).click(),
+      ErrorCode.NO_MATCH
+    );
+
     expect(err).toBeInstanceOf(Error);
     expect(err).toBeInstanceOf(CraftdriverError);
-    expect(typeof err!.hint).toBe('string');
+    expect(typeof err.hint).toBe('string');
   });
 });

--- a/tests/error-codes.test.ts
+++ b/tests/error-codes.test.ts
@@ -100,6 +100,9 @@ describe('error codes', () => {
     }
     expect(CraftdriverError.is(err, ErrorCode.DRIVER_ERROR)).toBe(true);
     expect(String((err as CraftdriverError).detail?.webDriverError)).toContain('stale element');
+    const stack = String((err as Error).stack);
+    expect(stack).toContain('tests/error-codes.test.ts');
+    expect(stack).not.toContain('src/lib/http.ts');
   });
 
   it('clicking a snapshot handle covered by an overlay throws DRIVER_ERROR (intercepted)', async () => {

--- a/tests/evaluate.test.ts
+++ b/tests/evaluate.test.ts
@@ -44,15 +44,16 @@ describe('evaluate()', () => {
   });
 
   it('element.evaluate() receives the DOM element as first arg', async () => {
-    const tag = await browser.find('#action-btn').evaluate((el) => (el as Element).tagName.toLowerCase());
+    const tag = await browser
+      .find('#action-btn')
+      .evaluate((el) => (el as Element).tagName.toLowerCase());
     expect(tag).toBe('button');
   });
 
   it('element.evaluate() passes extra args', async () => {
-    const has = await browser.find('#action-btn').evaluate(
-      (el, cls) => (el as Element).classList.contains(cls as string),
-      'active'
-    );
+    const has = await browser
+      .find('#action-btn')
+      .evaluate((el, cls) => (el as Element).classList.contains(cls as string), 'active');
     expect(has).toBe(true);
   });
 
@@ -60,9 +61,9 @@ describe('evaluate()', () => {
     // Returning a DOM node is not JSON-serializable via BiDi
     // (Classic executeScript silently coerces — skip that check)
     if (!browser.isBiDiEnabled()) return;
-    await expect(
-      browser.evaluate(() => document.body)
-    ).rejects.toThrow(/not JSON-serializable|node reference/i);
+    await expect(browser.evaluate(() => document.body)).rejects.toThrow(
+      /not JSON-serializable|node reference/i
+    );
   });
 
   // A Classic-first navigate returns at readyState === 'complete', which is not
@@ -79,9 +80,7 @@ describe('evaluate()', () => {
     conn.send = (method: string, params: Record<string, unknown> = {}) => {
       if (method === 'script.callFunction' && injected === 0) {
         injected++;
-        return Promise.reject(
-          new Error('BiDi error [unknown error]: execution contexts cleared')
-        );
+        return Promise.reject(new Error('BiDi error [unknown error]: execution contexts cleared'));
       }
       return original(method, params);
     };
@@ -96,7 +95,9 @@ describe('evaluate()', () => {
 
   it('does not retry a genuine in-script exception', async () => {
     await expect(
-      browser.evaluate(() => { throw new Error('boom'); })
+      browser.evaluate(() => {
+        throw new Error('boom');
+      })
     ).rejects.toThrow(/boom/);
   });
 });

--- a/tests/iframes.test.ts
+++ b/tests/iframes.test.ts
@@ -46,7 +46,7 @@ describe('Iframes', () => {
     const frame = await browser.frame('#my-frame');
     const result = await frame.evaluate(() => document.title);
     expect(typeof result).toBe('string');
-    expect(result).toBeTruthy();
+    expect(result.length).toBeGreaterThan(0);
   });
 
   it('can use frame.locator() to interact with elements', async () => {

--- a/tests/init-script.test.ts
+++ b/tests/init-script.test.ts
@@ -56,7 +56,9 @@ describe('addInitScript()', () => {
     try {
       const conn = (isolated as any).bidiSession.getConnection();
       const originalSend = conn.send.bind(conn);
-      restoreSend = () => { conn.send = originalSend; };
+      restoreSend = () => {
+        conn.send = originalSend;
+      };
       const methods: string[] = [];
       conn.send = (method: string, params: Record<string, unknown> = {}) => {
         methods.push(method);
@@ -82,7 +84,9 @@ describe('addInitScript()', () => {
   it('throws a clear error when BiDi is unavailable', async () => {
     const noBidi = await Browser.launch({ browserName: BROWSER_NAME, enableBiDi: false });
     try {
-      await expect(noBidi.addInitScript(() => { })).rejects.toThrow(/addInitScript\(\) requires BiDi/);
+      await expect(noBidi.addInitScript(() => {})).rejects.toThrow(
+        /addInitScript\(\) requires BiDi/
+      );
     } finally {
       await noBidi.quit();
     }

--- a/tests/keyboard.test.ts
+++ b/tests/keyboard.test.ts
@@ -51,6 +51,25 @@ describe('Keyboard interactions on keyboard.html', () => {
     await browser.expect('#enterResult').toHaveText('submitted');
   });
 
+  it('ElementHandle.press() uses the click fast path before pressing the key', async () => {
+    const driver = (browser as any).driver;
+    const originalWait = driver.wait.bind(driver);
+    let waitCalls = 0;
+    driver.wait = (...args: any[]) => {
+      waitCalls += 1;
+      return originalWait(...args);
+    };
+
+    try {
+      await browser.find('#enterTarget').press(Key.Enter);
+    } finally {
+      driver.wait = originalWait;
+    }
+
+    expect(waitCalls).toBe(0);
+    await browser.expect('#enterResult').toHaveText('submitted');
+  });
+
   it('modifier keys update status (Shift/Ctrl/Alt)', async () => {
     await browser.click('#editor');
     await browser.keyboard.down(Key.Shift);

--- a/tests/launch-options.test.ts
+++ b/tests/launch-options.test.ts
@@ -12,15 +12,12 @@ describe('Browser.launch() options', () => {
 
   // `args` is a Chromium-flag passthrough here (`--user-agent`); Firefox sets
   // its UA via a pref, not a CLI flag, so this assertion is Chromium-only.
-  it.runIf(IS_CHROMIUM)(
-    'args: forwards browser flags to goog:chromeOptions.args',
-    async () => {
-      const ua = 'CraftdriverArgsTest/1.0';
-      browser = await Browser.launch({ browserName: BROWSER_NAME, args: [`--user-agent=${ua}`] });
-      const actual = await browser.evaluate<string>('return navigator.userAgent');
-      expect(actual).toBe(ua);
-    }
-  );
+  it.runIf(IS_CHROMIUM)('args: forwards browser flags to goog:chromeOptions.args', async () => {
+    const ua = 'CraftdriverArgsTest/1.0';
+    browser = await Browser.launch({ browserName: BROWSER_NAME, args: [`--user-agent=${ua}`] });
+    const actual = await browser.evaluate<string>('return navigator.userAgent');
+    expect(actual).toBe(ua);
+  });
 
   it('args: omitting the option leaves launch unaffected', async () => {
     browser = await Browser.launch({ browserName: BROWSER_NAME });

--- a/tests/load-state.test.ts
+++ b/tests/load-state.test.ts
@@ -1,5 +1,4 @@
-import { describe, it, beforeAll, afterAll } from 'vitest';
-import { expect } from 'vitest';
+import { describe, it, beforeAll, afterAll, expect } from 'vitest';
 import { Browser } from '../src';
 import { EXAMPLES_BASE_URL, BROWSER_NAME } from './utils';
 
@@ -68,8 +67,8 @@ describe('BiDi-first navigation and load states', () => {
     // Approach: wait for 'networkidle' with a tiny timeout on a fresh navigateTo('none') invocation.
     await browser.navigateTo(`${EXAMPLES_BASE_URL}/dynamic.html`, { waitUntil: 'none' });
     // networkidle on a page that just started loading will almost certainly time out at 1ms
-    await expect(
-      browser.waitForLoadState('networkidle', { timeout: 1 })
-    ).rejects.toThrow(/timed out/);
+    await expect(browser.waitForLoadState('networkidle', { timeout: 1 })).rejects.toThrow(
+      /timed out/
+    );
   });
 });

--- a/tests/locator.test.ts
+++ b/tests/locator.test.ts
@@ -1,5 +1,4 @@
-import { describe, it, beforeAll, afterAll, beforeEach } from 'vitest';
-import { expect } from 'vitest';
+import { describe, it, beforeAll, afterAll, beforeEach, expect } from 'vitest';
 import { Browser } from '../src';
 import { EXAMPLES_BASE_URL, BROWSER_NAME } from './utils';
 
@@ -86,6 +85,6 @@ describe('Locator', () => {
     const handles = await browser.locator('.product').filter({ hasText: 'Gadget' }).all();
     expect(handles.length).toBe(2);
     const texts = await Promise.all(handles.map((h) => h.text()));
-    expect(texts.every((t) => t.includes('Gadget'))).toBe(true);
+    expect(texts).toEqual([expect.stringContaining('Gadget'), expect.stringContaining('Gadget')]);
   });
 });

--- a/tests/logs.test.ts
+++ b/tests/logs.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, beforeAll, afterAll, beforeEach, expect } from 'vitest';
-import { Browser } from '../src';
+import { Browser, type ConsoleMessage, type JavaScriptError } from '../src';
 import { EXAMPLES_BASE_URL, BROWSER_NAME, IS_CHROMIUM } from './utils';
 
 describe('Console Logs and JavaScript Errors', () => {
@@ -22,135 +22,139 @@ describe('Console Logs and JavaScript Errors', () => {
     await browser.quit();
   });
 
+  async function clickAndWaitForConsole(
+    selector: string,
+    predicate: (message: ConsoleMessage) => boolean
+  ): Promise<ConsoleMessage> {
+    const message = browser.logs.waitForConsole(predicate, 5000);
+    await browser.click(selector);
+    return message;
+  }
+
+  async function clickAndWaitForError(
+    selector: string,
+    predicate: (error: JavaScriptError) => boolean
+  ): Promise<JavaScriptError> {
+    const error = browser.logs.waitForError(predicate, 5000);
+    await browser.click(selector);
+    return error;
+  }
+
+  function expectConsoleMessage(
+    message: ConsoleMessage,
+    expected: {
+      level: ConsoleMessage['level'];
+      method: string;
+      stackTrace?: 'always' | 'chromium';
+    }
+  ): void {
+    expect(message).toMatchObject({
+      type: 'console',
+      level: expected.level,
+      method: expected.method,
+      timestamp: expect.any(Date),
+    });
+    const shouldHaveStack =
+      expected.stackTrace === 'always' || (expected.stackTrace === 'chromium' && IS_CHROMIUM);
+    if (shouldHaveStack) expect(message.stackTrace?.length).toBe(2);
+  }
+
+  function capturedErrorText(): string {
+    return browser.logs
+      .getErrors()
+      .map((error) => error.text)
+      .join('\n');
+  }
+
   describe('Console Log Capture', () => {
     it('captures console.log() messages', async () => {
-      const msgPromise = browser.logs.waitForConsole((m) => m.text.includes('Hello from console.log'), 5000);
-      await browser.click('#btn-console-log');
-      const logMessage = await msgPromise;
+      const logMessage = await clickAndWaitForConsole('#btn-console-log', (m) =>
+        m.text.includes('Hello from console.log')
+      );
 
-      expect(logMessage).toBeDefined();
-      expect(logMessage?.type).toBe('console');
-      expect(logMessage?.level).toBe('info');
-      expect(logMessage?.method).toBe('log');
-      expect(logMessage?.timestamp).instanceOf(Date);
       // Firefox only attaches stack traces to error-level entries.
-      if (IS_CHROMIUM) expect(logMessage?.stackTrace?.length).toEqual(2);
+      expectConsoleMessage(logMessage, { level: 'info', method: 'log', stackTrace: 'chromium' });
     });
 
     it('captures console.warn() messages', async () => {
-      const msgPromise = browser.logs.waitForConsole((m) => m.text.includes('This is a warning message'), 5000);
-      await browser.click('#btn-console-warn');
-      const logMessage = await msgPromise;
+      const logMessage = await clickAndWaitForConsole('#btn-console-warn', (m) =>
+        m.text.includes('This is a warning message')
+      );
 
-      expect(logMessage).toBeDefined();
-      expect(logMessage?.type).toBe('console');
-      expect(logMessage?.level).toBe('warn');
-      expect(logMessage?.method).toBe('warn');
-      expect(logMessage?.timestamp).instanceOf(Date);
-      if (IS_CHROMIUM) expect(logMessage?.stackTrace?.length).toEqual(2);
+      expectConsoleMessage(logMessage, { level: 'warn', method: 'warn', stackTrace: 'chromium' });
     });
 
     it('captures console.error() messages', async () => {
-      const msgPromise = browser.logs.waitForConsole((m) => m.text.includes('This is an error message'), 5000);
-      await browser.click('#btn-console-error');
-      const logMessage = await msgPromise;
+      const logMessage = await clickAndWaitForConsole('#btn-console-error', (m) =>
+        m.text.includes('This is an error message')
+      );
 
-      expect(logMessage).toBeDefined();
-      expect(logMessage?.type).toBe('console');
-      expect(logMessage?.level).toBe('error');
-      expect(logMessage?.method).toBe('error');
-      expect(logMessage?.timestamp).instanceOf(Date);
-      expect(logMessage?.stackTrace?.length).toEqual(2);
+      expectConsoleMessage(logMessage, { level: 'error', method: 'error', stackTrace: 'always' });
     });
 
     it('captures console.info() messages', async () => {
-      const msgPromise = browser.logs.waitForConsole((m) => m.text.includes('This is an info message'), 5000);
-      await browser.click('#btn-console-info');
-      const logMessage = await msgPromise;
+      const logMessage = await clickAndWaitForConsole('#btn-console-info', (m) =>
+        m.text.includes('This is an info message')
+      );
 
-      expect(logMessage).toBeDefined();
-      expect(logMessage?.type).toBe('console');
-      expect(logMessage?.level).toBe('info');
-      expect(logMessage?.method).toBe('info');
-      expect(logMessage?.timestamp).instanceOf(Date);
-      if (IS_CHROMIUM) expect(logMessage?.stackTrace?.length).toEqual(2);
+      expectConsoleMessage(logMessage, { level: 'info', method: 'info', stackTrace: 'chromium' });
     });
 
     it('captures console.debug() messages', async () => {
-      const msgPromise = browser.logs.waitForConsole((m) => m.text.includes('This is a debug message'), 5000);
-      await browser.click('#btn-console-debug');
-      const logMessage = await msgPromise;
+      const logMessage = await clickAndWaitForConsole('#btn-console-debug', (m) =>
+        m.text.includes('This is a debug message')
+      );
 
-      expect(logMessage).toBeDefined();
-      expect(logMessage?.type).toBe('console');
-      expect(logMessage?.level).toBe('debug');
-      expect(logMessage?.method).toBe('debug');
-      expect(logMessage?.timestamp).instanceOf(Date);
-      if (IS_CHROMIUM) expect(logMessage?.stackTrace?.length).toEqual(2);
+      expectConsoleMessage(logMessage, { level: 'debug', method: 'debug', stackTrace: 'chromium' });
     });
   });
 
   describe('Complex Console Output', () => {
     it('captures console logs with objects', async () => {
-      const msgPromise = browser.logs.waitForConsole(
-        (m) => m.text.includes('User object') || m.text.includes('testuser'),
-        5000
+      await clickAndWaitForConsole(
+        '#btn-log-object',
+        (m) => m.text.includes('User object') || m.text.includes('testuser')
       );
-      await browser.click('#btn-log-object');
-      await msgPromise;
     });
 
     it('captures console logs with arrays', async () => {
-      const msgPromise = browser.logs.waitForConsole((m) => m.text.includes('Array'), 5000);
-      await browser.click('#btn-log-array');
-      await msgPromise;
+      await clickAndWaitForConsole('#btn-log-array', (m) => m.text.includes('Array'));
     });
 
     it('captures console logs with multiple arguments', async () => {
-      const msgPromise = browser.logs.waitForConsole(
-        (m) => m.text.includes('Multiple') && m.text.includes('arguments'),
-        5000
+      await clickAndWaitForConsole(
+        '#btn-log-multiple',
+        (m) => m.text.includes('Multiple') && m.text.includes('arguments')
       );
-      await browser.click('#btn-log-multiple');
-      await msgPromise;
     });
   });
 
   describe('JavaScript Error Capture', () => {
     it('captures thrown Error', async () => {
-      const errorPromise = browser.logs.waitForError(
-        (e) => e.text.includes('This is a thrown Error'),
-        5000
+      await clickAndWaitForError('#btn-throw-error', (e) =>
+        e.text.includes('This is a thrown Error')
       );
-      await browser.click('#btn-throw-error');
-      await errorPromise;
     });
 
     it('captures TypeError', async () => {
-      const errorPromise = browser.logs.waitForError(
-        (e) => e.text.includes('TypeError') || e.text.includes('Cannot read property'),
-        5000
+      await clickAndWaitForError(
+        '#btn-throw-type',
+        (e) => e.text.includes('TypeError') || e.text.includes('Cannot read property')
       );
-      await browser.click('#btn-throw-type');
-      await errorPromise;
     });
 
     it('captures ReferenceError', async () => {
-      const errorPromise = browser.logs.waitForError(
-        (e) => e.text.includes('ReferenceError') || e.text.includes('not defined'),
-        5000
+      await clickAndWaitForError(
+        '#btn-throw-reference',
+        (e) => e.text.includes('ReferenceError') || e.text.includes('not defined')
       );
-      await browser.click('#btn-throw-reference');
-      await errorPromise;
     });
 
     it('captures eval syntax error', async () => {
-      const errorPromise = browser.logs.waitForError(
-        (e) => e.text.includes('SyntaxError') || e.text.toLowerCase().includes('syntax'),
-        5000
+      await clickAndWaitForError(
+        '#btn-throw-syntax',
+        (e) => e.text.includes('SyntaxError') || e.text.toLowerCase().includes('syntax')
       );
-      await browser.click('#btn-throw-syntax');
-      await errorPromise;
     });
   });
 
@@ -161,12 +165,7 @@ describe('Console Logs and JavaScript Errors', () => {
       // Wait a bit for promise rejection to be logged
       await browser.pause(500);
 
-      const errors = browser.logs.getErrors();
-      const promiseError = errors.find((e) => e.text.includes('Unhandled promise rejection'));
-
-      if (!promiseError) {
-        throw new Error('Expected to capture unhandled promise rejection');
-      }
+      expect(capturedErrorText()).toContain('Unhandled promise rejection');
     });
 
     it('captures async function error', async () => {
@@ -174,12 +173,7 @@ describe('Console Logs and JavaScript Errors', () => {
 
       await browser.pause(500);
 
-      const errors = browser.logs.getErrors();
-      const asyncError = errors.find((e) => e.text.includes('Error inside async function'));
-
-      if (!asyncError) {
-        throw new Error('Expected to capture async function error');
-      }
+      expect(capturedErrorText()).toContain('Error inside async function');
     });
 
     it('captures error in setTimeout', async () => {
@@ -188,43 +182,31 @@ describe('Console Logs and JavaScript Errors', () => {
       // Wait for setTimeout to fire
       await browser.pause(500);
 
-      const errors = browser.logs.getErrors();
-      const timeoutError = errors.find((e) => e.text.includes('Error inside setTimeout'));
-
-      if (!timeoutError) {
-        throw new Error('Expected to capture setTimeout error');
-      }
+      expect(capturedErrorText()).toContain('Error inside setTimeout');
     });
   });
 
   describe('DOM Errors', () => {
     it('captures null element access error', async () => {
-      const errorPromise = browser.logs.waitForError(
-        (e) => e.text.includes('null') || e.text.includes('Cannot') || e.text.includes('textContent'),
-        5000
+      await clickAndWaitForError(
+        '#btn-null-access',
+        (e) =>
+          e.text.includes('null') || e.text.includes('Cannot') || e.text.includes('textContent')
       );
-      await browser.click('#btn-null-access');
-      await errorPromise;
     });
 
     it('captures invalid selector error', async () => {
-      const errorPromise = browser.logs.waitForError(
-        (e) => e.text.toLowerCase().includes('selector') || e.text.toLowerCase().includes('valid'),
-        5000
+      await clickAndWaitForError(
+        '#btn-invalid-selector',
+        (e) => e.text.toLowerCase().includes('selector') || e.text.toLowerCase().includes('valid')
       );
-      await browser.click('#btn-invalid-selector');
-      await errorPromise;
     });
   });
 
   describe('Clear Logs', () => {
     it('can clear captured messages', async () => {
-      const logPromise = browser.logs.waitForConsole((m) => m.method === 'log', 5000);
-      await browser.click('#btn-console-log');
-      await logPromise;
-      const warnPromise = browser.logs.waitForConsole((m) => m.method === 'warn', 5000);
-      await browser.click('#btn-console-warn');
-      await warnPromise;
+      await clickAndWaitForConsole('#btn-console-log', (m) => m.method === 'log');
+      await clickAndWaitForConsole('#btn-console-warn', (m) => m.method === 'warn');
       expect(browser.logs.getMessages().length).toBeGreaterThan(0);
 
       browser.logs.clearLogs();
@@ -233,12 +215,9 @@ describe('Console Logs and JavaScript Errors', () => {
     });
 
     it('can clear captured errors', async () => {
-      const errorPromise = browser.logs.waitForError(
-        (e) => e.text.includes('This is a thrown Error'),
-        5000
+      await clickAndWaitForError('#btn-throw-error', (e) =>
+        e.text.includes('This is a thrown Error')
       );
-      await browser.click('#btn-throw-error');
-      await errorPromise;
       expect(browser.logs.getErrors().length).toBeGreaterThan(0);
 
       browser.logs.clearLogs();
@@ -249,7 +228,7 @@ describe('Console Logs and JavaScript Errors', () => {
 
   describe('Event Subscription', () => {
     it('subscribes to JavaScript errors and takes screenshot on error', async () => {
-      let capturedError: any = null;
+      let capturedError: JavaScriptError | undefined;
       let screenshotTaken = false;
 
       // 1. Subscribe to JavaScript errors - code runs when error happens
@@ -264,19 +243,22 @@ describe('Console Logs and JavaScript Errors', () => {
         5000
       );
 
-      // 3. Trigger an error
-      await browser.click('#btn-throw-error');
+      try {
+        // 3. Trigger an error
+        await browser.click('#btn-throw-error');
 
-      // 4. Wait for the error event (instead of a fixed pause)
-      await errorPromise;
+        // 4. Wait for the error event (instead of a fixed pause)
+        await errorPromise;
 
-      // 5. Verify subscription code got executed
-      expect(capturedError).not.toBeNull();
-      expect(capturedError.type).toBe('javascript');
-      expect(capturedError.text).toContain('This is a thrown Error');
-      expect(screenshotTaken).toBe(true);
-
-      unsubscribe();
+        // 5. Verify subscription code got executed
+        expect(capturedError).toMatchObject({
+          type: 'javascript',
+          text: expect.stringContaining('This is a thrown Error'),
+        });
+        expect(screenshotTaken).toBe(true);
+      } finally {
+        unsubscribe();
+      }
     });
   });
 });

--- a/tests/mcp-smoke.test.ts
+++ b/tests/mcp-smoke.test.ts
@@ -28,6 +28,14 @@ interface RpcFailure {
 }
 type RpcResponse = RpcSuccess | RpcFailure;
 
+function parseRpcLine(line: string): RpcResponse | undefined {
+  try {
+    return JSON.parse(line) as RpcResponse;
+  } catch {
+    return undefined;
+  }
+}
+
 /**
  * Minimal MCP client over a child process. One pending request at a
  * time is enough for a smoke test — easier to reason about than
@@ -41,14 +49,10 @@ class McpHarness {
   private stderr = '';
 
   async start(): Promise<void> {
-    this.child = spawn(
-      'node',
-      [CLI_BIN, 'mcp', '--browser', BROWSER_NAME],
-      {
-        env: { ...process.env, HEADLESS: 'true' },
-        stdio: ['pipe', 'pipe', 'pipe'],
-      },
-    );
+    this.child = spawn('node', [CLI_BIN, 'mcp', '--browser', BROWSER_NAME], {
+      env: { ...process.env, HEADLESS: 'true' },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
     this.child.stdout.setEncoding('utf8');
     this.child.stdout.on('data', (chunk: string) => {
       this.buf += chunk;
@@ -57,12 +61,8 @@ class McpHarness {
         const line = this.buf.slice(0, nl).trim();
         this.buf = this.buf.slice(nl + 1);
         if (!line) continue;
-        let msg: RpcResponse;
-        try {
-          msg = JSON.parse(line) as RpcResponse;
-        } catch {
-          continue;
-        }
+        const msg = parseRpcLine(line);
+        if (!msg) continue;
         const cb = this.pending.get(msg.id);
         if (cb) {
           this.pending.delete(msg.id);
@@ -96,16 +96,12 @@ class McpHarness {
     const id = this.nextId++;
     return new Promise<RpcResponse>((resolveReq) => {
       this.pending.set(id, resolveReq);
-      this.child.stdin.write(
-        JSON.stringify({ jsonrpc: '2.0', id, method, params }) + '\n',
-      );
+      this.child.stdin.write(JSON.stringify({ jsonrpc: '2.0', id, method, params }) + '\n');
     });
   }
 
   notify(method: string, params: Record<string, unknown>): void {
-    this.child.stdin.write(
-      JSON.stringify({ jsonrpc: '2.0', method, params }) + '\n',
-    );
+    this.child.stdin.write(JSON.stringify({ jsonrpc: '2.0', method, params }) + '\n');
   }
 
   get capturedStderr(): string {
@@ -145,7 +141,7 @@ describe('MCP smoke', () => {
         'browser_snapshot',
         'browser_status',
         'browser_wait',
-      ].sort(),
+      ].sort()
     );
   });
 
@@ -155,7 +151,7 @@ describe('MCP smoke', () => {
       arguments: { url: loginUrl },
     })) as RpcSuccess;
     const navResult = nav.result as { isError?: boolean; structuredContent: { result: unknown } };
-    expect(navResult.isError).toBeFalsy();
+    expect(navResult.isError ?? false).toBe(false);
 
     const snap = (await mcp.request('tools/call', {
       name: 'browser_snapshot',
@@ -165,7 +161,7 @@ describe('MCP smoke', () => {
       isError?: boolean;
       structuredContent: { result: { url: string; lines: string[] } };
     };
-    expect(snapResult.isError).toBeFalsy();
+    expect(snapResult.isError ?? false).toBe(false);
     const { url, lines } = snapResult.structuredContent.result;
     expect(url).toContain('/login.html');
     const all = lines.join('\n');
@@ -191,7 +187,7 @@ describe('MCP smoke', () => {
     // NO_MATCH (zero matches at t=0), TIMEOUT_WAITING_VISIBLE (matched
     // but never actionable), or generic TIMEOUT — all valid signals.
     expect(result.structuredContent.error.code).toMatch(
-      /^(NO_MATCH|TIMEOUT(_WAITING_(VISIBLE|STATE))?)$/,
+      /^(NO_MATCH|TIMEOUT(_WAITING_(VISIBLE|STATE))?)$/
     );
   });
 

--- a/tests/mobile-emulation.test.ts
+++ b/tests/mobile-emulation.test.ts
@@ -3,52 +3,58 @@ import { Browser } from '../src';
 import { EXAMPLES_BASE_URL } from './utils';
 
 describe('Mobile Emulation', () => {
-  let browser: Browser;
+  let browser: Browser | undefined;
   const baseUrl = EXAMPLES_BASE_URL;
 
+  async function launchMobile(options: Parameters<typeof Browser.launch>[0]): Promise<Browser> {
+    browser = await Browser.launch(options);
+    return browser;
+  }
+
   afterEach(async () => {
-    await browser.quit();
+    await browser?.quit();
+    browser = undefined;
   });
 
   it('emulates iPhone 14 using device preset', async () => {
-    browser = await Browser.launch({
+    const mobileBrowser = await launchMobile({
       browserName: 'chrome',
       mobileEmulation: 'iPhone 14',
     });
 
-    await browser.navigateTo(`${baseUrl}/mobile.html`);
+    await mobileBrowser.navigateTo(`${baseUrl}/mobile.html`);
 
     // Verify viewport width matches iPhone 14 (390px)
-    await browser.expect('#viewport-width').toHaveText('390px');
+    await mobileBrowser.expect('#viewport-width').toHaveText('390px');
 
     // Verify device pixel ratio
-    await browser.expect('#pixel-ratio').toHaveText('3');
+    await mobileBrowser.expect('#pixel-ratio').toHaveText('3');
 
     // Verify touch support is enabled
-    await browser.expect('#touch-support').toContainText('Yes');
+    await mobileBrowser.expect('#touch-support').toContainText('Yes');
 
     // Verify mobile user agent
-    await browser.expect('#user-agent').toContainText('iPhone');
+    await mobileBrowser.expect('#user-agent').toContainText('iPhone');
   });
 
   it('emulates Pixel 7 using device preset', async () => {
-    browser = await Browser.launch({
+    const mobileBrowser = await launchMobile({
       browserName: 'chrome',
       mobileEmulation: 'Pixel 7',
     });
 
-    await browser.navigateTo(`${baseUrl}/mobile.html`);
+    await mobileBrowser.navigateTo(`${baseUrl}/mobile.html`);
 
     // Verify viewport width matches Pixel 7 (412px)
-    await browser.expect('#viewport-width').toHaveText('412px');
+    await mobileBrowser.expect('#viewport-width').toHaveText('412px');
 
     // Verify Android user agent
-    await browser.expect('#user-agent').toContainText('Android');
-    await browser.expect('#user-agent').toContainText('Pixel 7');
+    await mobileBrowser.expect('#user-agent').toContainText('Android');
+    await mobileBrowser.expect('#user-agent').toContainText('Pixel 7');
   });
 
   it('uses custom device metrics', async () => {
-    browser = await Browser.launch({
+    const mobileBrowser = await launchMobile({
       browserName: 'chrome',
       mobileEmulation: {
         deviceMetrics: {
@@ -62,42 +68,42 @@ describe('Mobile Emulation', () => {
       },
     });
 
-    await browser.navigateTo(`${baseUrl}/mobile.html`);
+    await mobileBrowser.navigateTo(`${baseUrl}/mobile.html`);
 
     // Verify custom viewport
-    await browser.expect('#viewport-width').toHaveText('320px');
-    await browser.expect('#pixel-ratio').toHaveText('2');
+    await mobileBrowser.expect('#viewport-width').toHaveText('320px');
+    await mobileBrowser.expect('#pixel-ratio').toHaveText('2');
 
     // Verify custom user agent
-    await browser.expect('#user-agent').toContainText('CustomMobileAgent');
+    await mobileBrowser.expect('#user-agent').toContainText('CustomMobileAgent');
 
     // Verify touch support
-    await browser.expect('#touch-support').toContainText('Yes');
+    await mobileBrowser.expect('#touch-support').toContainText('Yes');
   });
 
   it('shows mobile view indicator for narrow viewport', async () => {
-    browser = await Browser.launch({
+    const mobileBrowser = await launchMobile({
       browserName: 'chrome',
       mobileEmulation: 'iPhone SE',
     });
 
-    await browser.navigateTo(`${baseUrl}/mobile.html`);
+    await mobileBrowser.navigateTo(`${baseUrl}/mobile.html`);
 
     // iPhone SE width is 375px - should show mobile view
-    await browser.expect('#responsive-indicator').toContainText('Mobile View');
+    await mobileBrowser.expect('#responsive-indicator').toContainText('Mobile View');
   });
 
   it('shows portrait orientation for tall viewport', async () => {
-    browser = await Browser.launch({
+    const mobileBrowser = await launchMobile({
       browserName: 'chrome',
       mobileEmulation: {
         deviceMetrics: { width: 390, height: 844, pixelRatio: 3 },
       },
     });
 
-    await browser.navigateTo(`${baseUrl}/mobile.html`);
+    await mobileBrowser.navigateTo(`${baseUrl}/mobile.html`);
 
     // Tall viewport = portrait
-    await browser.expect('#orientation-box').toContainText('Portrait');
+    await mobileBrowser.expect('#orientation-box').toContainText('Portrait');
   });
 });

--- a/tests/navigation.test.ts
+++ b/tests/navigation.test.ts
@@ -36,7 +36,7 @@ describe('Navigation, content and viewport', () => {
     await browser.reload();
 
     const after = await browser.evaluate<number | undefined>('return window.__marker');
-    expect(after).toBeFalsy();
+    expect(after).toBeUndefined();
   });
 
   it('content() returns the serialized document', async () => {

--- a/tests/network.test.ts
+++ b/tests/network.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, beforeAll, afterAll, afterEach } from 'vitest';
+import { describe, it, beforeAll, afterAll, afterEach, expect } from 'vitest';
 import { Browser } from '../src';
 import { EXAMPLES_BASE_URL, BROWSER_NAME } from './utils';
 
@@ -11,7 +11,7 @@ describe('Network Mocking and Interception', () => {
   beforeAll(async () => {
     browser = await Browser.launch({
       browserName: BROWSER_NAME,
-      enableBiDi: true
+      enableBiDi: true,
     });
   });
 
@@ -25,18 +25,18 @@ describe('Network Mocking and Interception', () => {
   });
 
   it('mocks GET and POST endpoints', async () => {
-    await browser.navigateTo(`${networkPageUrl}`);
+    await browser.navigateTo(networkPageUrl);
 
     // Mock GET endpoint
     await browser.network?.mock('**/api/users', {
       status: 200,
-      body: { users: [{ id: 999, name: 'Mocked User', email: 'mocked@test.com' }] }
+      body: { users: [{ id: 999, name: 'Mocked User', email: 'mocked@test.com' }] },
     });
 
     // Mock POST endpoint
     await browser.network?.mock('**/api/login', {
       status: 200,
-      body: { success: true, token: 'intercepted-token-xyz' }
+      body: { success: true, token: 'intercepted-token-xyz' },
     });
 
     await browser.click('#fetch-users-btn');
@@ -47,45 +47,48 @@ describe('Network Mocking and Interception', () => {
   });
 
   it('mocks external API call with CORS headers', async () => {
-    await browser.navigateTo(`${networkPageUrl}`);
+    await browser.navigateTo(networkPageUrl);
 
-    await browser.network?.mock({
-      type: 'pattern',
-      protocol: 'https',
-      hostname: 'jsonplaceholder.typicode.com',
-      pathname: '/posts/1'
-    }, {
-      status: 200,
-      headers: {
-        'Content-Type': 'application/json',
-        'Access-Control-Allow-Origin': '*'
+    await browser.network?.mock(
+      {
+        type: 'pattern',
+        protocol: 'https',
+        hostname: 'jsonplaceholder.typicode.com',
+        pathname: '/posts/1',
       },
-      body: {
-        userId: 99,
-        id: 99,
-        title: 'Mocked External Post',
-        body: 'Crafdriver is awesome!'
+      {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+          'Access-Control-Allow-Origin': '*',
+        },
+        body: {
+          userId: 99,
+          id: 99,
+          title: 'Mocked External Post',
+          body: 'Crafdriver is awesome!',
+        },
       }
-    });
+    );
 
     await browser.click('#fetch-external-btn');
     await browser.expect('#external-result').toContainText('Mocked External Post');
   });
 
   it('mocks parallel requests with different responses', async () => {
-    await browser.navigateTo(`${networkPageUrl}`);
+    await browser.navigateTo(networkPageUrl);
 
     await browser.network?.mock('**/api/items/1', {
       status: 200,
-      body: { id: 1, name: 'Mocked Item 1', price: 99.99 }
+      body: { id: 1, name: 'Mocked Item 1', price: 99.99 },
     });
     await browser.network?.mock('**/api/items/2', {
       status: 200,
-      body: { id: 2, name: 'Mocked Item 2', price: 199.99 }
+      body: { id: 2, name: 'Mocked Item 2', price: 199.99 },
     });
     await browser.network?.mock('**/api/items/3', {
       status: 200,
-      body: { id: 3, name: 'Mocked Item 3', price: 299.99 }
+      body: { id: 3, name: 'Mocked Item 3', price: 299.99 },
     });
 
     await browser.click('#fetch-parallel-btn');
@@ -95,11 +98,11 @@ describe('Network Mocking and Interception', () => {
   });
 
   it('mocks slow endpoint with instant response', async () => {
-    await browser.navigateTo(`${networkPageUrl}`);
+    await browser.navigateTo(networkPageUrl);
 
     await browser.network?.mock('**/api/slow', {
       status: 200,
-      body: { message: 'Instantly mocked (no delay!)' }
+      body: { message: 'Instantly mocked (no delay!)' },
     });
 
     const startTime = Date.now();
@@ -107,13 +110,11 @@ describe('Network Mocking and Interception', () => {
     await browser.expect('#slow-result').toContainText('Instantly mocked');
     const elapsed = Date.now() - startTime;
 
-    if (elapsed > 1000) {
-      throw new Error(`Expected fast response but took ${elapsed}ms`);
-    }
+    expect(elapsed).toBeLessThanOrEqual(1000);
   });
 
   it('mocks error responses (404 and 500)', async () => {
-    await browser.navigateTo(`${networkPageUrl}`);
+    await browser.navigateTo(networkPageUrl);
 
     // Test 404
     await browser.network?.mock('**/api/users', { status: 404, body: { error: 'Not found' } });
@@ -129,7 +130,7 @@ describe('Network Mocking and Interception', () => {
   });
 
   it('intercepts requests, captures details, and modifies response', async () => {
-    await browser.navigateTo(`${networkPageUrl}`);
+    await browser.navigateTo(networkPageUrl);
 
     let interceptedUrl = '';
     let interceptedMethod = '';
@@ -139,18 +140,14 @@ describe('Network Mocking and Interception', () => {
       interceptedMethod = request.method;
       return {
         status: 200,
-        body: { users: [{ id: 888, name: 'Intercepted User', email: 'intercepted@test.com' }] }
+        body: { users: [{ id: 888, name: 'Intercepted User', email: 'intercepted@test.com' }] },
       };
     });
 
     await browser.click('#fetch-users-btn');
     await browser.expect('#users-result').toContainText('Intercepted User');
 
-    if (!interceptedUrl.includes('/api/users')) {
-      throw new Error(`Expected to intercept /api/users but got "${interceptedUrl}"`);
-    }
-    if (interceptedMethod !== 'GET') {
-      throw new Error(`Expected GET method but got "${interceptedMethod}"`);
-    }
+    expect(interceptedUrl).toContain('/api/users');
+    expect(interceptedMethod).toBe('GET');
   });
 });

--- a/tests/pages.test.ts
+++ b/tests/pages.test.ts
@@ -18,44 +18,37 @@ describe('Pages (tabs / popups)', () => {
     await browser.navigateTo(`${baseUrl}/popup.html`);
   });
 
+  async function openPopup(): Promise<Page> {
+    const popup = await browser.waitForPage(() => browser.click('#open-popup'));
+    await popup.waitForLoadState('load');
+    return popup;
+  }
+
   it('browser.pages() lists the current top-level page', async () => {
     const pages = await browser.pages();
     expect(pages.length).toBeGreaterThanOrEqual(1);
   });
 
   it('waitForPage() captures a popup opened by a button click', async () => {
-    const popup = await browser.waitForPage(async () => {
-      await browser.click('#open-popup');
-    });
-
-    await popup.waitForLoadState('load');
+    const popup = await openPopup();
     // Firefox may report load before document.title is populated — poll until it is.
     await expect.poll(() => popup.title(), { timeout: 5000 }).toBe('Popup Target');
   });
 
   it('popup Page.url() returns the popup URL', async () => {
-    const popup = await browser.waitForPage(async () => {
-      await browser.click('#open-popup');
-    });
-    await popup.waitForLoadState('load');
+    const popup = await openPopup();
     // Firefox may briefly report about:blank for a freshly opened popup — poll.
     await expect.poll(() => popup.url(), { timeout: 5000 }).toContain('popup-target.html');
   });
 
   it('popup Page can find elements', async () => {
-    const popup = await browser.waitForPage(async () => {
-      await browser.click('#open-popup');
-    });
-    await popup.waitForLoadState('load');
+    const popup = await openPopup();
     const text = await popup.find('#popup-heading').text();
     expect(text).toBe('Popup Window');
   });
 
   it('popup Page.evaluate() runs script in the popup', async () => {
-    const popup = await browser.waitForPage(async () => {
-      await browser.click('#open-popup');
-    });
-    await popup.waitForLoadState('load');
+    const popup = await openPopup();
     // Firefox may report load before document.title is populated — poll until it is.
     await expect
       .poll(() => popup.evaluate<string>(() => document.title), { timeout: 5000 })
@@ -75,7 +68,7 @@ describe('Pages (tabs / popups)', () => {
   it('openPage() without a url returns an empty new tab', async () => {
     const page = await browser.openPage();
     expect(page).toBeInstanceOf(Page);
-    expect(typeof page.id()).toBe('string');
+    expect(page.id()).toEqual(expect.any(String));
   });
 });
 

--- a/tests/screenshots.test.ts
+++ b/tests/screenshots.test.ts
@@ -7,9 +7,10 @@ import { EXAMPLES_BASE_URL, BROWSER_NAME } from './utils';
  * width and height. We parse them directly so the test does not depend
  * on an image-processing library.
  */
+const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+
 function pngSize(buf: Buffer): { width: number; height: number } {
-  // PNG magic: 89 50 4E 47 0D 0A 1A 0A
-  if (buf.length < 24 || buf[0] !== 0x89 || buf[1] !== 0x50 || buf[2] !== 0x4e || buf[3] !== 0x47) {
+  if (buf.length < 24 || !buf.subarray(0, PNG_SIGNATURE.length).equals(PNG_SIGNATURE)) {
     throw new Error('not a PNG');
   }
   return {
@@ -65,9 +66,9 @@ describe('screenshots', () => {
   });
 
   it('fullPage and selector are mutually exclusive', async () => {
-    await expect(
-      browser.screenshot({ fullPage: true, selector: '#s1' })
-    ).rejects.toThrow(/mutually exclusive/);
+    await expect(browser.screenshot({ fullPage: true, selector: '#s1' })).rejects.toThrow(
+      /mutually exclusive/
+    );
   });
 
   it('selector screenshot returns just the element', async () => {

--- a/tests/storage.test.ts
+++ b/tests/storage.test.ts
@@ -1,5 +1,4 @@
-import { describe, it, beforeAll, afterAll, beforeEach } from 'vitest';
-import { expect } from 'vitest';
+import { describe, it, beforeAll, afterAll, beforeEach, expect } from 'vitest';
 import { Browser } from '../src';
 import { EXAMPLES_BASE_URL, BROWSER_NAME } from './utils';
 import * as fs from 'fs';
@@ -10,17 +9,38 @@ describe('Session State Management APIs', () => {
   const baseUrl = EXAMPLES_BASE_URL;
   const statePath = path.join(__dirname, '../.test-session-state.json');
 
+  function deleteStateFile(): void {
+    fs.rmSync(statePath, { force: true });
+  }
+
+  async function cookieValue(name: string, target: Browser = browser): Promise<string | undefined> {
+    const cookies = await target.storage.getCookies();
+    return cookies.find((cookie) => cookie.name === name)?.value;
+  }
+
+  async function withStoredBrowser<T>(run: (storedBrowser: Browser) => Promise<T>): Promise<T> {
+    const storedBrowser = await Browser.launch({
+      browserName: BROWSER_NAME,
+      storageState: statePath,
+    });
+    try {
+      return await run(storedBrowser);
+    } finally {
+      await storedBrowser.quit();
+    }
+  }
+
   beforeAll(async () => {
     browser = await Browser.launch({ browserName: BROWSER_NAME });
   });
 
   afterAll(async () => {
     await browser.quit();
-    if (fs.existsSync(statePath)) fs.unlinkSync(statePath);
+    deleteStateFile();
   });
 
   beforeEach(async () => {
-    if (fs.existsSync(statePath)) fs.unlinkSync(statePath);
+    deleteStateFile();
     await browser.navigateTo(`${baseUrl}/session.html`);
     await browser.storage.clearCookies();
   });
@@ -31,13 +51,10 @@ describe('Session State Management APIs', () => {
         name: 'test_cookie',
         value: 'test_value',
         domain: 'localhost',
-        path: '/'
+        path: '/',
       });
 
-      const cookies = await browser.storage.getCookies();
-      const testCookie = cookies.find(c => c.name === 'test_cookie');
-
-      expect(testCookie?.value).toBe('test_value');
+      expect(await cookieValue('test_cookie')).toBe('test_value');
     });
 
     it('clearCookies removes all cookies', async () => {
@@ -45,13 +62,11 @@ describe('Session State Management APIs', () => {
         name: 'clear_test',
         value: 'clear_value',
         domain: 'localhost',
-        path: '/'
+        path: '/',
       });
 
       await browser.storage.clearCookies();
-      const cookies = await browser.storage.getCookies();
-
-      expect(cookies.length).toBe(0);
+      expect(await browser.storage.getCookies()).toHaveLength(0);
     });
   });
 
@@ -61,28 +76,30 @@ describe('Session State Management APIs', () => {
         name: 'save_load_test',
         value: 'test_value',
         domain: 'localhost',
-        path: '/'
+        path: '/',
       });
 
       await browser.saveState(statePath);
       await browser.storage.clearCookies();
       await browser.loadState(statePath);
 
-      const cookies = await browser.storage.getCookies();
-      const loadedCookie = cookies.find(c => c.name === 'save_load_test');
-
-      expect(loadedCookie?.value).toBe('test_value');
+      expect(await cookieValue('save_load_test')).toBe('test_value');
     });
 
     it('respects includeLocalStorage option', async () => {
-      await browser.storage.addCookie({ name: 'test', value: 'val', domain: 'localhost', path: '/' });
+      await browser.storage.addCookie({
+        name: 'test',
+        value: 'val',
+        domain: 'localhost',
+        path: '/',
+      });
 
       await browser.saveState(statePath, { includeLocalStorage: false });
 
       const state = JSON.parse(fs.readFileSync(statePath, 'utf-8'));
       const localStorageKeys = state.localStorage ? Object.keys(state.localStorage) : [];
 
-      expect(localStorageKeys.length).toBe(0);
+      expect(localStorageKeys).toEqual([]);
     });
   });
 
@@ -92,20 +109,15 @@ describe('Session State Management APIs', () => {
         name: 'launch_test',
         value: 'launch_value',
         domain: 'localhost',
-        path: '/'
+        path: '/',
       });
 
       await browser.saveState(statePath);
 
-      const browser2 = await Browser.launch({ browserName: BROWSER_NAME, storageState: statePath });
-      try {
+      await withStoredBrowser(async (browser2) => {
         await browser2.navigateTo(`${baseUrl}/session.html`);
-        const cookies = await browser2.storage.getCookies();
-        const launchCookie = cookies.find(c => c.name === 'launch_test');
-        expect(launchCookie?.value).toBe('launch_value');
-      } finally {
-        await browser2.quit();
-      }
+        expect(await cookieValue('launch_test', browser2)).toBe('launch_value');
+      });
     });
   });
 
@@ -119,16 +131,12 @@ describe('Session State Management APIs', () => {
 
       await browser.saveState(statePath);
 
-      const browser2 = await Browser.launch({ browserName: BROWSER_NAME, storageState: statePath });
-      try {
+      await withStoredBrowser(async (browser2) => {
         await browser2.navigateTo(`${baseUrl}/login.html`);
         await browser2.expect('#welcome').toBeVisible();
         await browser2.expect('#welcome').toContainText('testuser');
-        expect(await browser2.find('#login-form').isVisible()).toBe(false);
-      } finally {
-        await browser2.quit();
-      }
+        await browser2.expect('#login-form').not.toBeVisible();
+      });
     });
   });
 });
-

--- a/tests/timeouts.test.ts
+++ b/tests/timeouts.test.ts
@@ -32,9 +32,7 @@ describe('configurable timeouts', () => {
   it('per-call { timeout } overrides the default', async () => {
     browser.setDefaultTimeout(5000);
     const start = Date.now();
-    await expect(
-      browser.waitForVisible('#missing', { timeout: 400 })
-    ).rejects.toThrow();
+    await expect(browser.waitForVisible('#missing', { timeout: 400 })).rejects.toThrow();
     expect(Date.now() - start).toBeLessThan(2500);
   });
 

--- a/tests/tracing.test.ts
+++ b/tests/tracing.test.ts
@@ -6,15 +6,21 @@ import { Browser } from '../src';
 import type { TraceEvent } from '../src';
 import { EXAMPLES_BASE_URL, BROWSER_NAME } from './utils';
 
+function parseTraceLine(line: string): TraceEvent | null {
+  try {
+    return JSON.parse(line) as TraceEvent;
+  } catch {
+    return null;
+  }
+}
+
 /** Parse an ndjson file, tolerating a missing trailing newline / partial last line. */
 function readNdjson(path: string): TraceEvent[] {
   const text = readFileSync(path, 'utf8');
   return text
     .split('\n')
     .filter((l) => l.length > 0)
-    .map((l) => {
-      try { return JSON.parse(l) as TraceEvent; } catch { return null; }
-    })
+    .map(parseTraceLine)
     .filter((e): e is TraceEvent => e !== null);
 }
 
@@ -37,7 +43,7 @@ describe('Tracing', () => {
 
   afterEach(async () => {
     // Make sure no trace leaks across tests.
-    try { await browser.stopTrace(); } catch { /* not running */ }
+    await browser.stopTrace().catch(() => undefined);
     rmSync(tmpRoot, { recursive: true, force: true });
   });
 
@@ -55,7 +61,9 @@ describe('Tracing', () => {
     expect((metas[0] as { startedAt?: string }).startedAt).toBeDefined();
     expect((metas[1] as { endedAt?: string }).endedAt).toBeDefined();
 
-    const actions = events.filter((e): e is Extract<TraceEvent, { type: 'action' }> => e.type === 'action');
+    const actions = events.filter(
+      (e): e is Extract<TraceEvent, { type: 'action' }> => e.type === 'action'
+    );
     expect(actions.map((a) => a.name)).toEqual(['navigateTo', 'fill', 'click']);
     const fill = actions.find((a) => a.name === 'fill')!;
     expect(fill.args).toEqual(['alice']);
@@ -143,10 +151,11 @@ describe('Tracing', () => {
     await browser.stopTrace();
 
     const events = readNdjson(join(dir, 'trace.ndjson'));
-    expect(events.some((e) => e.type === 'action')).toBe(false);
-    expect(events.some((e) => e.type === 'screenshot')).toBe(false);
+    const eventTypes = events.map((e) => e.type);
+    expect(eventTypes).not.toContain('action');
+    expect(eventTypes).not.toContain('screenshot');
     // Navigation pillar still on.
-    expect(events.some((e) => e.type === 'navigation')).toBe(true);
+    expect(eventTypes).toContain('navigation');
     expect(existsSync(join(dir, 'screenshots'))).toBe(false);
   });
 

--- a/tests/upload.test.ts
+++ b/tests/upload.test.ts
@@ -25,8 +25,8 @@ describe('File upload — setInputFiles()', () => {
   });
 
   it('throws a clear error on a non-file input', async () => {
-    await expect(
-      browser.find('#text-input').setInputFiles(FIXTURE)
-    ).rejects.toThrow('setInputFiles() requires an <input type="file"> element');
+    await expect(browser.find('#text-input').setInputFiles(FIXTURE)).rejects.toThrow(
+      'setInputFiles() requires an <input type="file"> element'
+    );
   });
 });

--- a/tests/wait-for-network.test.ts
+++ b/tests/wait-for-network.test.ts
@@ -6,6 +6,25 @@ describe('waitForRequest and waitForResponse', () => {
   let browser: Browser;
   const networkPageUrl = `${EXAMPLES_BASE_URL}/network.html?bidi=true`;
 
+  async function clickAndWaitForResponse(
+    matcher: Parameters<Browser['waitForResponse']>[0],
+    selector: string
+  ) {
+    const [response] = await Promise.all([
+      browser.waitForResponse(matcher),
+      browser.click(selector),
+    ]);
+    return response;
+  }
+
+  async function clickAndWaitForRequest(
+    matcher: Parameters<Browser['waitForRequest']>[0],
+    selector: string
+  ) {
+    const [request] = await Promise.all([browser.waitForRequest(matcher), browser.click(selector)]);
+    return request;
+  }
+
   beforeAll(async () => {
     browser = await Browser.launch({ browserName: BROWSER_NAME, enableBiDi: true });
     await browser.navigateTo(networkPageUrl);
@@ -20,54 +39,45 @@ describe('waitForRequest and waitForResponse', () => {
   });
 
   it('waitForResponse resolves with the response after a button click', async () => {
-    const [res] = await Promise.all([
-      browser.waitForResponse('**/api/users'),
-      browser.click('#fetch-users-btn'),
-    ]);
+    const res = await clickAndWaitForResponse('**/api/users', '#fetch-users-btn');
 
     expect(res.url).toContain('/api/users');
     expect(res.status).toBeGreaterThanOrEqual(200);
   });
 
   it('waitForRequest resolves with request info', async () => {
-    const [req] = await Promise.all([
-      browser.waitForRequest('**/api/login'),
-      browser.click('#post-login-btn'),
-    ]);
+    const req = await clickAndWaitForRequest('**/api/login', '#post-login-btn');
 
     expect(req.url).toContain('/api/login');
     expect(req.method).toBe('POST');
   });
 
   it('predicate form matches on response properties', async () => {
-    const [res] = await Promise.all([
-      browser.waitForResponse(r => r.url.includes('/api/users') && r.status >= 200),
-      browser.click('#fetch-users-btn'),
-    ]);
+    const res = await clickAndWaitForResponse(
+      (r) => r.url.includes('/api/users') && r.status >= 200,
+      '#fetch-users-btn'
+    );
 
     expect(res.url).toContain('/api/users');
   });
 
   it('predicate form matches on request properties', async () => {
-    const [req] = await Promise.all([
-      browser.waitForRequest(r => r.url.includes('/api/login') && r.method === 'POST'),
-      browser.click('#post-login-btn'),
-    ]);
+    const req = await clickAndWaitForRequest(
+      (r) => r.url.includes('/api/login') && r.method === 'POST',
+      '#post-login-btn'
+    );
 
     expect(req.method).toBe('POST');
   });
 
   it('timeout rejects with a clear message including the pattern', async () => {
-    await expect(
-      browser.waitForResponse('**/api/nonexistent', { timeout: 1000 })
-    ).rejects.toThrow('waitForResponse("**/api/nonexistent") timed out after 1000ms');
+    await expect(browser.waitForResponse('**/api/nonexistent', { timeout: 1000 })).rejects.toThrow(
+      'waitForResponse("**/api/nonexistent") timed out after 1000ms'
+    );
   });
 
   it('response includes headers object and numeric status', async () => {
-    const [res] = await Promise.all([
-      browser.waitForResponse('**/api/users'),
-      browser.click('#fetch-users-btn'),
-    ]);
+    const res = await clickAndWaitForResponse('**/api/users', '#fetch-users-btn');
 
     expect(typeof res.headers).toBe('object');
     expect(typeof res.status).toBe('number');


### PR DESCRIPTION
## Summary

Extends the optimistic-fast-path pattern from fill (4b3c6c6) and click (2d28d47)
to three more happy-path actions: try the action immediately, fall back to the
old wait-for-visible path only on recoverable find/interactability errors.

- **`clear()`** — new `src/lib/clearFastPath.ts` (mirrors `fillFastPath.ts`),
  wired into `Browser.clear()` and `ElementHandle.clear()`.
- **`ElementHandle.press()`** — now reuses the click fast path before sending
  the key, instead of always waiting for visibility first.
- **`ElementHandle.hover()`** — moves to the element origin directly instead of
  computing a document-relative center via `getRect()` and moving in viewport
  space. This also **fixes a real bug**: the old coordinates could disagree
  once the page was scrolled, throwing `move target out of bounds` on elements
  below the fold. Added a regression test (`hovers an element scrolled below
  the fold`) that reproduces the failure on the old code path and passes on
  the new one.

## Performance

Measured with a throwaway micro-bench script (not part of the competitive
`tests/perf/*.perf.ts` suite, since these methods are not benchmarked across
all compared libraries there) on localhost Chrome, n=60 per op, two runs each:

| Method | Before (median) | After (median) | Delta |
|---|---|---|---|
| `clear()` | 30.6 / 30.5 ms | 24.7 / 24.7 ms | ~19% faster |
| `ElementHandle.press()` | 53.0 / 52.3 ms | 47.1 / 47.1 ms | ~11% faster |
| `ElementHandle.hover()` | 24.0 / 22.5 ms | 16.5 / 16.6 ms | ~29% faster |

Each win is ~one WebDriver round trip removed from the happy path, consistent
with the fill/click precedent.

## Test plan

- [x] `npm run build` passes
- [x] `npm run lint` passes
- [x] `npm run docs:api:check` passes (no unreviewed public API surface change)
- [x] `tests/element-handle.test.ts` + `tests/keyboard.test.ts` — 29/29 passing
      (includes 4 new tests: clear fast-path skip, clear still waits when
      needed, press fast-path skip, hover on a scrolled-out element)
- [x] Confirmed the scrolled-hover test fails with `move target out of bounds`
      on the pre-change code, passes after — verified it is a real regression
      guard, not a false-positive test

🤖 Generated with [Claude Code](https://claude.com/claude-code)
