### PR TITLE
fix: harden Browser.launch (session-create timeout + concurrent driver downloads)

### DIFF
--- a/src/lib/driver.ts
+++ b/src/lib/driver.ts
@@ -4,6 +4,7 @@ import { By } from './by.js';
 import { WebElement, W3C_ELEMENT_KEY, LEGACY_ELEMENT_KEY } from './webelement.js';
 import { WebDriverWait, type Condition, type WaitOptions } from './wait.js';
 import { CraftdriverError, ErrorCode } from './errors.js';
+import { SESSION_CREATE_TIMEOUT_MS } from './timing.js';
 
 function isMoveTargetOutOfBounds(err: unknown): boolean {
   if (!CraftdriverError.is(err, ErrorCode.DRIVER_ERROR)) return false;
@@ -27,6 +28,7 @@ export class Driver {
         method: 'POST',
         path: '/session',
         body: { capabilities: { alwaysMatch: caps } },
+        timeoutMs: SESSION_CREATE_TIMEOUT_MS,
       });
     } catch (err) {
       client.close();

--- a/src/lib/driverManager.ts
+++ b/src/lib/driverManager.ts
@@ -343,31 +343,49 @@ async function downloadChromedriver(browserVersion: string): Promise<string> {
 
   const chosen = candidates[0];
   const entry = chosen.downloads.chromedriver!.find((d) => d.platform === platform)!;
-  const tmpZip = path.join(cacheDir(), `_chromedriver-${chosen.version}.zip`);
 
   process.stderr.write(
     `[craftdriver] Downloading chromedriver ${chosen.version}…\n`,
   );
   fs.mkdirSync(cacheDir(), { recursive: true });
-  await httpsDownload(entry.url, tmpZip);
 
-  // CfT zip layout: chromedriver-<platform>/chromedriver[.exe]
-  const extractDir = path.join(cacheDir(), `_extract_chromedriver_${chosen.version}`);
-  extractZip(tmpZip, extractDir);
-  fs.unlinkSync(tmpZip);
+  // Download and extract inside a per-call unique working directory. Several
+  // launches can resolve the same missing version at once (parallel test
+  // workers, each its own process, share the one on-disk cache); a fixed temp
+  // path let them clobber each other's zip mid-download or delete it
+  // mid-extract ("unzip: cannot find or open …" / "invalid compressed data").
+  // mkdtempSync hands each caller a distinct directory — safe across processes —
+  // and the finally removes it whatever happens.
+  const workDir = fs.mkdtempSync(path.join(cacheDir(), '_dl-chromedriver-'));
+  try {
+    const tmpZip = path.join(workDir, 'chromedriver.zip');
+    await httpsDownload(entry.url, tmpZip);
 
-  const innerBin = path.join(extractDir, `chromedriver-${platform}`, binName);
-  if (!fs.existsSync(innerBin)) {
-    throw new Error(
-      `Unexpected zip layout: could not find ${innerBin} after extraction.`,
-    );
+    // CfT zip layout: chromedriver-<platform>/chromedriver[.exe]
+    const extractDir = path.join(workDir, 'extract');
+    extractZip(tmpZip, extractDir);
+
+    const innerBin = path.join(extractDir, `chromedriver-${platform}`, binName);
+    if (!fs.existsSync(innerBin)) {
+      throw new Error(
+        `Unexpected zip layout: could not find ${innerBin} after extraction.`,
+      );
+    }
+
+    fs.mkdirSync(driverDir, { recursive: true });
+    // A concurrent resolver may have placed the binary first. On POSIX rename
+    // atomically replaces it; on Windows rename onto an existing file throws, so
+    // treat an already-present destination as success.
+    try {
+      fs.renameSync(innerBin, driverBin);
+    } catch (err) {
+      if (!fs.existsSync(driverBin)) throw err;
+    }
+
+    if (os.platform() !== 'win32') fs.chmodSync(driverBin, 0o755);
+  } finally {
+    fs.rmSync(workDir, { recursive: true, force: true });
   }
-
-  fs.mkdirSync(driverDir, { recursive: true });
-  fs.renameSync(innerBin, driverBin);
-  fs.rmSync(extractDir, { recursive: true, force: true });
-
-  if (os.platform() !== 'win32') fs.chmodSync(driverBin, 0o755);
 
   return driverBin;
 }
@@ -412,20 +430,45 @@ async function downloadGeckodriver(): Promise<string> {
       );
     }
 
-    const tmpFile = path.join(cacheDir(), `_geckodriver-${version}${ext}`);
     process.stderr.write(`[craftdriver] Downloading geckodriver ${version}…\n`);
     fs.mkdirSync(cacheDir(), { recursive: true });
-    await httpsDownload(asset.browser_download_url, tmpFile);
 
-    fs.mkdirSync(driverDir, { recursive: true });
-    if (ext === '.zip') {
-      extractZip(tmpFile, driverDir);
-    } else {
-      extractTarGz(tmpFile, driverDir);
+    // Per-call unique working directory so parallel resolvers don't share a
+    // fixed temp path and extract dir — same race, and fix, as
+    // downloadChromedriver above. (`test:firefox` runs with --maxWorkers=2.)
+    const workDir = fs.mkdtempSync(path.join(cacheDir(), '_dl-geckodriver-'));
+    try {
+      const tmpFile = path.join(workDir, `geckodriver${ext}`);
+      await httpsDownload(asset.browser_download_url, tmpFile);
+
+      // geckodriver archives contain the binary at the archive root.
+      const extractDir = path.join(workDir, 'extract');
+      if (ext === '.zip') {
+        extractZip(tmpFile, extractDir);
+      } else {
+        extractTarGz(tmpFile, extractDir);
+      }
+
+      const innerBin = path.join(extractDir, binName);
+      if (!fs.existsSync(innerBin)) {
+        throw new Error(
+          `Unexpected archive layout: could not find ${innerBin} after extraction.`,
+        );
+      }
+
+      fs.mkdirSync(driverDir, { recursive: true });
+      // See downloadChromedriver: tolerate a destination a concurrent resolver
+      // already placed (Windows rename onto an existing file throws).
+      try {
+        fs.renameSync(innerBin, driverBin);
+      } catch (err) {
+        if (!fs.existsSync(driverBin)) throw err;
+      }
+
+      if (os.platform() !== 'win32') fs.chmodSync(driverBin, 0o755);
+    } finally {
+      fs.rmSync(workDir, { recursive: true, force: true });
     }
-    fs.unlinkSync(tmpFile);
-
-    if (os.platform() !== 'win32') fs.chmodSync(driverBin, 0o755);
   }
 
   // Refresh TTL record regardless of whether we downloaded a new version.

--- a/src/lib/http.ts
+++ b/src/lib/http.ts
@@ -110,7 +110,12 @@ function buildTransportError(err: Error, method: string, path: string): Craftdri
 export class HttpClient {
   constructor(private endpoint: WebDriverEndpoint) {}
 
-  async send<T = unknown>({ method, path, body }: RequestOptions): Promise<CommandResponse<T>> {
+  async send<T = unknown>({
+    method,
+    path,
+    body,
+    timeoutMs,
+  }: RequestOptions): Promise<CommandResponse<T>> {
     const base = `${this.endpoint.protocol}://${this.endpoint.hostname}:${this.endpoint.port}${this.endpoint.path ?? ''}`;
     const url = new URL(path, base);
     const isHttps = url.protocol === 'https:';
@@ -129,10 +134,26 @@ export class HttpClient {
     const transport = isHttps ? (https as unknown as typeof http) : http;
 
     return await new Promise<CommandResponse<T>>((resolve, reject) => {
+      let settled = false;
+      let timer: NodeJS.Timeout | undefined;
+
+      const settleResolve = (value: CommandResponse<T>): void => {
+        if (settled) return;
+        settled = true;
+        if (timer) clearTimeout(timer);
+        resolve(value);
+      };
+      const settleReject = (err: unknown): void => {
+        if (settled) return;
+        settled = true;
+        if (timer) clearTimeout(timer);
+        reject(err);
+      };
+
       const req = transport.request(url, options, (res: http.IncomingMessage) => {
         const chunks: Buffer[] = [];
         res.on('data', (c: Buffer) => chunks.push(Buffer.from(c)));
-        res.on('error', (err: Error) => reject(buildTransportError(err, method, path)));
+        res.on('error', (err: Error) => settleReject(buildTransportError(err, method, path)));
         res.on('end', () => {
           const status = res.statusCode ?? 0;
           const text = Buffer.concat(chunks).toString('utf8');
@@ -141,15 +162,15 @@ export class HttpClient {
           // error response. Gate on status alone (see buildDriverError) so a
           // successful command returning error-shaped data is never misread.
           if (status !== 200) {
-            return reject(buildDriverError(status, text, method, path));
+            return settleReject(buildDriverError(status, text, method, path));
           }
 
-          if (!text) return resolve({ value: undefined as unknown as T });
+          if (!text) return settleResolve({ value: undefined as unknown as T });
           try {
             const json = JSON.parse(text) as CommandResponse<T>;
-            resolve(json);
+            settleResolve(json);
           } catch {
-            reject(
+            settleReject(
               new CraftdriverError(
                 ErrorCode.DRIVER_ERROR,
                 `Invalid JSON in WebDriver response for ${method} ${path}: ${text}`,
@@ -159,7 +180,25 @@ export class HttpClient {
           }
         });
       });
-      req.on('error', (err: Error) => reject(buildTransportError(err, method, path)));
+      req.on('error', (err: Error) => settleReject(buildTransportError(err, method, path)));
+
+      // Only armed when the caller opts in (timeoutMs is undefined for every
+      // regular WebDriver command today) — a hung connection otherwise waits
+      // forever with no way for the caller to recover. See Driver.create(),
+      // the one call site that currently sets this.
+      if (timeoutMs) {
+        timer = setTimeout(() => {
+          settleReject(
+            new CraftdriverError(
+              ErrorCode.DRIVER_ERROR,
+              `WebDriver command ${method} ${path} timed out after ${timeoutMs}ms waiting for a response`,
+              { detail: { method, path, timeoutMs } }
+            )
+          );
+          req.destroy();
+        }, timeoutMs);
+      }
+
       if (payload) req.write(payload);
       req.end();
     });

--- a/src/lib/timing.ts
+++ b/src/lib/timing.ts
@@ -70,6 +70,20 @@ export const BIDI_TIMEOUT_MS = 30_000;
 export const DRIVER_READINESS_TIMEOUT_MS = 5_000;
 
 /**
+ * Bound on the `POST /session` request itself, separate from
+ * {@link DRIVER_READINESS_TIMEOUT_MS} (which only covers the driver's `/status`
+ * endpoint coming up). Once the driver process is ready it still has to launch
+ * and hand off control of the actual browser; if that browser hangs or crashes
+ * mid-handshake, chromedriver/geckodriver can leave the request socket open
+ * with no response and no error. Without this, `Browser.launch()` hangs
+ * indefinitely — the only thing that ever unblocks it is a *caller's* timeout
+ * (e.g. a test framework's hook timeout), which throws a generic error with no
+ * indication anything driver-related was involved. Same 30s order of magnitude
+ * as {@link BIDI_TIMEOUT_MS} / {@link DEFAULT_NAVIGATION_TIMEOUT_MS}.
+ */
+export const SESSION_CREATE_TIMEOUT_MS = 30_000;
+
+/**
  * Readiness deadline for geckodriver specifically — it takes longer than
  * chromedriver to spin up Marionette and start listening.
  */

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -16,6 +16,8 @@ export interface RequestOptions {
   method: 'GET' | 'POST' | 'DELETE';
   path: string;
   body?: unknown;
+  /** Abort the request and reject if no response arrives within this many ms. Unbounded when omitted. */
+  timeoutMs?: number;
 }
 
 export interface WebDriverEndpoint {

--- a/tests/driver-download-concurrency.test.ts
+++ b/tests/driver-download-concurrency.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Regression test for the temp-file race in driverManager's download path.
+ *
+ * Several launches can resolve the same *missing* chromedriver version at the
+ * same time — most commonly parallel vitest workers, each its own process,
+ * sharing the one on-disk cache. They all pass the "already downloaded?" check
+ * together and take the download+extract path at once. With a fixed temp path
+ * (`_chromedriver-<ver>.zip` / `_extract_chromedriver_<ver>`) one process's
+ * cleanup deleted the zip another was mid-extract on, surfacing as
+ * `unzip failed: cannot find or open …` and a failed launch.
+ *
+ * This test forces that exact condition in one process via Promise.all against
+ * a cold, isolated cache: everything up to `downloadChromedriver`'s first
+ * network await runs synchronously, so all callers reach the download step
+ * before any finishes. It makes real network requests (first-run download from
+ * Chrome for Testing); the cache is isolated to a temp dir.
+ */
+
+import { describe, it, beforeAll, afterAll, expect } from 'vitest';
+import { resolveChromeDriver } from '../src/lib/driverManager';
+import path from 'path';
+import os from 'os';
+import fs from 'fs';
+
+/** Remove a list of keys from process.env, returning a restore function. */
+function unsetEnvVars(keys: string[]): () => void {
+  const saved: Record<string, string | undefined> = {};
+  for (const key of keys) {
+    saved[key] = process.env[key];
+    delete process.env[key];
+  }
+  return () => {
+    for (const key of keys) {
+      if (saved[key] === undefined) delete process.env[key];
+      else process.env[key] = saved[key];
+    }
+  };
+}
+
+describe('driver manager — concurrent resolution', () => {
+  const testCacheDir = path.join(os.tmpdir(), `craftdriver-concurrent-cache-${process.pid}`);
+  let restoreEnv = () => {};
+
+  beforeAll(() => {
+    // Start from an empty cache so every caller exercises the download path.
+    fs.rmSync(testCacheDir, { recursive: true, force: true });
+
+    restoreEnv = unsetEnvVars([
+      'CRAFTDRIVER_CHROMEDRIVER_PATH',
+      'CRAFTDRIVER_GECKODRIVER_PATH',
+      'CRAFTDRIVER_DRIVER_PATH',
+      'CRAFTDRIVER_CACHE_DIR',
+      'CRAFTDRIVER_OFFLINE',
+      'CHROMEDRIVER_PATH',
+      'SE_CHROMEDRIVER',
+      'CRAFTDRIVER_SKIP_PATH_PROBE',
+    ]);
+
+    // Skip the PATH probe so a pre-installed chromedriver (CI runners, nvm envs)
+    // does not short-circuit before the auto-download path we want to test.
+    process.env.CRAFTDRIVER_SKIP_PATH_PROBE = '1';
+    process.env.CRAFTDRIVER_CACHE_DIR = testCacheDir;
+  });
+
+  afterAll(() => {
+    restoreEnv?.();
+    fs.rmSync(testCacheDir, { recursive: true, force: true });
+  });
+
+  it('resolves the same chromedriver from concurrent callers without a temp-file race', async () => {
+    const N = 3;
+    const results = await Promise.all(Array.from({ length: N }, () => resolveChromeDriver()));
+
+    // All callers land on the one cached binary, and it exists + is executable.
+    const unique = new Set(results.map((p) => path.resolve(p)));
+    expect(unique.size).toBe(1);
+
+    const bin = results[0];
+    expect(fs.existsSync(bin)).toBe(true);
+    if (os.platform() !== 'win32') {
+      expect(fs.statSync(bin).mode & 0o100).toBe(0o100);
+    }
+  }, 120_000);
+});

--- a/tests/http-client-timeout.test.ts
+++ b/tests/http-client-timeout.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Regression coverage for the `timeoutMs` option on HttpClient.send() (see
+ * Driver.create(), the one call site that sets it for POST /session).
+ *
+ * Reproduces the CI failure mode that motivated this: a driver process that
+ * accepts the connection but never responds (e.g. because the browser it
+ * spawned hung or crashed mid-handshake) used to leave Browser.launch()
+ * pending forever, with nothing in craftdriver to detect or report it — only
+ * an external timeout (a test framework's hook timeout) ever unblocked it,
+ * and that produced a bare "Hook timed out" with no indication craftdriver
+ * was even involved.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import http from 'http';
+import { HttpClient } from '../src/lib/http.js';
+import { CraftdriverError, ErrorCode } from '../src/lib/errors.js';
+import type { WebDriverEndpoint } from '../src/lib/types.js';
+
+function listen(server: http.Server): Promise<number> {
+  return new Promise((resolve, reject) => {
+    server.on('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address();
+      resolve(typeof addr === 'object' && addr ? addr.port : 0);
+    });
+  });
+}
+
+function endpointFor(port: number): WebDriverEndpoint {
+  return { protocol: 'http', hostname: '127.0.0.1', port, path: '' };
+}
+
+describe('HttpClient timeoutMs', () => {
+  let server: http.Server | undefined;
+
+  afterEach(async () => {
+    if (!server) return;
+    const s = server;
+    server = undefined;
+    await new Promise<void>((resolve) => s.close(() => resolve()));
+  });
+
+  it('rejects with a clear DRIVER_ERROR instead of hanging when the server never responds', async () => {
+    server = http.createServer(() => {
+      // Deliberately never call res.end() — simulates a driver whose browser
+      // hung mid-session-creation: the connection is accepted, nothing comes back.
+    });
+    const port = await listen(server);
+    const client = new HttpClient(endpointFor(port));
+
+    const start = Date.now();
+    const err = await client
+      .send({ method: 'POST', path: '/session', body: {}, timeoutMs: 200 })
+      .catch((e: unknown) => e);
+    const elapsed = Date.now() - start;
+
+    expect(CraftdriverError.is(err, ErrorCode.DRIVER_ERROR)).toBe(true);
+    expect((err as CraftdriverError).message).toMatch(/timed out after 200ms/);
+    // Bounded by timeoutMs, not left hanging until some outer caller gives up.
+    expect(elapsed).toBeLessThan(1000);
+  });
+
+  it('does not fire when the response arrives before the timeout (happy path unaffected)', async () => {
+    server = http.createServer((_req, res) => {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ value: { sessionId: 'abc-123' } }));
+    });
+    const port = await listen(server);
+    const client = new HttpClient(endpointFor(port));
+
+    const result = await client.send<{ sessionId: string }>({
+      method: 'POST',
+      path: '/session',
+      body: {},
+      timeoutMs: 5000,
+    });
+
+    expect(result.value).toMatchObject({ sessionId: 'abc-123' });
+  });
+
+  it('never times out when timeoutMs is omitted, even for a response that takes a while', async () => {
+    server = http.createServer((_req, res) => {
+      setTimeout(() => {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ value: 'ok' }));
+      }, 150);
+    });
+    const port = await listen(server);
+    const client = new HttpClient(endpointFor(port));
+
+    const result = await client.send({ method: 'GET', path: '/status' });
+    expect(result.value).toBe('ok');
+  });
+});


### PR DESCRIPTION
## Summary

Two related hardening fixes for `Browser.launch()`, each in its own commit.

### 1. Bound session creation with a request timeout

Follow-up to the flaky Chrome run on #27's CI (`beforeAll` timing out inside `Browser.launch()` with zero error, just a bare vitest `Hook timed out in 30000ms`).

Traced the hang: `Driver.create()` -> `HttpClient.send()` issues the `POST /session` request with no client-side timeout - no `timeout` option, no `req.setTimeout()`. If chromedriver accepts the connection but its underlying Chrome process hangs or crashes mid-handshake, the request just sits open forever. Nothing in craftdriver bounds it; it relies entirely on the caller's own timeout (here, vitest's `hookTimeout`) to eventually kill it - which explains the content-free failure and the orphaned `chromedriver`/`chrome` processes the runner had to force-kill afterward.

- Add optional `timeoutMs` to `RequestOptions` / `HttpClient.send()`. Undefined by default, so every existing call site (every regular WebDriver command - click, evaluate, executeAsyncScript, ...) is byte-for-byte unaffected; only opts in where explicitly set.
- Set it only on the one call site that needs it: `Driver.create()`'s `POST /session`, via a new `SESSION_CREATE_TIMEOUT_MS = 30_000` constant (same order of magnitude as the existing `BIDI_TIMEOUT_MS` / `DEFAULT_NAVIGATION_TIMEOUT_MS`).
- On timeout: reject with a `CraftdriverError(DRIVER_ERROR)` stating what timed out, then destroy the socket.

Scoped deliberately narrow - did not touch `CHROME_SESSION_MAX_ATTEMPTS` (retry policy is a separate, riskier change) or add a timeout to the generic command path (would risk breaking legitimately slow calls like `executeAsyncScript`).

### 2. Isolate driver downloads to per-call temp dirs

While validating the above at full-suite parallelism, I hit a **separate, pre-existing** flake (present on `main`, untouched by commit 1): `downloadChromedriver` / `downloadGeckodriver` wrote to **fixed** temp paths in the shared cache (`_chromedriver-<ver>.zip`, `_extract_chromedriver_<ver>`). When several launches resolve the same *missing* version at once - most commonly parallel vitest workers, each its own process - they clobber each other's zip mid-download or delete it mid-extract, surfacing as `unzip: cannot find or open ...` / `invalid compressed data` and a failed `Browser.launch()`. A plausible source of intermittent CI download failures, most likely to bite on a cold cache (e.g. after a Chrome bump on the runner image).

- Give each download a unique `mkdtemp()` working directory, cleaned up in a `finally`.
- Tolerate a destination binary a concurrent resolver placed first (POSIX rename replaces atomically; Windows rename onto an existing file throws).
- Fixed in **both** drivers for parity (`test:firefox` runs `--maxWorkers=2`).

## Test plan
- [x] New `tests/http-client-timeout.test.ts`: hung server -> rejects fast with `DRIVER_ERROR` and a clear message; response-before-timeout resolves normally; omitting `timeoutMs` never fires even on a slow response.
- [x] New `tests/driver-download-concurrency.test.ts`: concurrent `resolveChromeDriver()` against a cold isolated cache. Confirmed it **fails** on the old fixed-path code (reproduced the exact `invalid compressed data` corruption) and **passes** with the fix.
- [x] `driver-manager.test.ts` (real cold-cache download -> extract -> chmod -> launch through the refactored code) still green, covering the happy path.
- [x] `npm run lint`, `npm run build`, `npm run docs:api:check` clean - no public API surface change.
- [x] Full `HEADLESS=true npm test` green (41 files / 311 tests) at normal parallelism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
