### PR TITLE
feat: custom browser binary support + CI-driver auto-detection + macOS/Windows CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,3 +44,62 @@ jobs:
         run: npm run test:firefox
         env:
           HEADLESS: true
+
+  cross-platform-smoke:
+    # Fast confidence check that craftdriver can launch and drive a session at
+    # all on macOS/Windows — not full coverage (build-and-test above already
+    # runs everything on Ubuntu). Also the real-world proof that the
+    # CI-provided driver directory detection (CHROMEWEBDRIVER/GECKOWEBDRIVER,
+    # see driverManager.ts) actually engages on these runner images, not just
+    # doc-research.
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '24'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Start test server
+        shell: bash
+        run: npm run serve &
+
+      # No top-level `timeout` command here (unlike build-and-test's `timeout 2m
+      # bash -c "..."` above): macOS runners don't ship GNU coreutils' `timeout`
+      # (only BSD userland). A portable retry-count loop works on macOS, Windows
+      # (via Git Bash), and Ubuntu alike.
+      - name: Wait for server
+        shell: bash
+        run: |
+          for i in $(seq 1 120); do
+            curl -sf http://127.0.0.1:8080/login.html && exit 0
+            sleep 1
+          done
+          echo "Server did not start in time" >&2
+          exit 1
+
+      # shell: bash on every step below: GitHub Actions defaults to PowerShell
+      # on Windows runners, where background `&` doesn't mean what the steps
+      # above assume. Git Bash ships on windows-latest, so forcing `shell: bash`
+      # makes these steps behave identically across macOS/Windows.
+      - name: Chrome smoke test
+        shell: bash
+        run: npx vitest run tests/chrome-smoke.test.ts
+        env:
+          HEADLESS: true
+
+      - name: Firefox smoke test
+        shell: bash
+        run: npx vitest run tests/firefox-smoke.test.ts
+        env:
+          HEADLESS: true
+          BROWSER_NAME: firefox

--- a/docs/browser-api.md
+++ b/docs/browser-api.md
@@ -33,6 +33,7 @@ const browser = await Browser.launch({
 | `storageState` | `string` | — | Path to a session-state JSON file to load on startup |
 | `mobileEmulation` | `MobileEmulation \| DeviceName` | — | Mobile device emulation settings (Chrome/Chromium only) |
 | `downloadsDir` | `string` | temp dir | Directory where downloaded files are saved |
+| `browserPath` | `string` | — | Custom browser binary to launch (Chrome/Chromium/Firefox) — see [Driver Configuration → Browser Binary Configuration](./driver-configuration.md#browser-binary-configuration) |
 
 ## Navigation
 

--- a/docs/driver-configuration.md
+++ b/docs/driver-configuration.md
@@ -8,10 +8,11 @@ Craftdriver resolves the WebDriver binary through a chain — first match wins:
 | 2 | `CRAFTDRIVER_CHROMEDRIVER_PATH` / `CRAFTDRIVER_GECKODRIVER_PATH` env var |
 | 3 | `CRAFTDRIVER_DRIVER_PATH` env var (generic fallback for either browser) |
 | 4 | Legacy/Selenium-compatible env vars: `CHROMEDRIVER_PATH`, `SE_CHROMEDRIVER` (chromedriver) or `GECKODRIVER_PATH`, `GECKODRIVER_FILEPATH`, `SE_GECKODRIVER` (geckodriver) |
-| 5 | **Cached auto-resolution** — the path a previous auto-resolve settled on, reused within the `CRAFTDRIVER_DRIVER_TTL` window |
-| 6 | `chromedriver` / `geckodriver` in `node_modules/.bin` |
-| 7 | `chromedriver` / `geckodriver` on `PATH` |
-| 8 | **Auto-download from Chrome for Testing / GitHub** ← the zero-config default |
+| 5 | Known CI-provided driver directories (e.g. GitHub Actions' `CHROMEWEBDRIVER` / `GECKOWEBDRIVER`) — see [CI platform detection](#ci-platform-detection) |
+| 6 | **Cached auto-resolution** — the path a previous auto-resolve settled on, reused within the `CRAFTDRIVER_DRIVER_TTL` window |
+| 7 | `chromedriver` / `geckodriver` in `node_modules/.bin` |
+| 8 | `chromedriver` / `geckodriver` on `PATH` |
+| 9 | **Auto-download from Chrome for Testing / GitHub** ← the zero-config default |
 
 Downloaded drivers are cached in `~/.cache/craftdriver`, and so is the
 *resolution itself* — which driver path to use. Within the
@@ -26,6 +27,23 @@ major version after a browser upgrade, the driver is re-resolved and
 re-downloaded if needed. Only the driver binary is ever downloaded, never the
 browser itself. Explicit configuration (steps 1–4) always takes precedence over
 the cache.
+
+## CI platform detection
+
+On **GitHub Actions**, craftdriver recognizes the runner's own pre-installed,
+version-matched driver automatically — no configuration needed. GitHub's
+`ubuntu-latest`, `macos-latest`, and `windows-latest` images all publish a
+driver directory via `CHROMEWEBDRIVER` / `GECKOWEBDRIVER` env vars (see
+[actions/runner-images](https://github.com/actions/runner-images)); craftdriver
+checks those directories as step 5 above, before falling back to its own
+cache/PATH-probe/download machinery.
+
+This is best-effort: if a future runner image drops or renames these vars,
+craftdriver falls through safely to the next resolution step rather than
+erroring. No other CI platform is auto-detected yet — set
+`CRAFTDRIVER_CHROMEDRIVER_PATH` / `CRAFTDRIVER_GECKODRIVER_PATH` explicitly on
+other providers (or to pin a non-default driver even on GitHub Actions;
+explicit config always wins, per the chain above).
 
 ## Environment variables
 

--- a/docs/driver-configuration.md
+++ b/docs/driver-configuration.md
@@ -45,6 +45,70 @@ erroring. No other CI platform is auto-detected yet — set
 other providers (or to pin a non-default driver even on GitHub Actions;
 explicit config always wins, per the chain above).
 
+## Browser Binary Configuration
+
+Everything above resolves the **driver** (chromedriver/geckodriver). A
+separate, independent chain resolves the **browser** binary itself — useful
+for a non-default Chrome/Chromium install or a portable Firefox build.
+
+The `browserPath` option itself is opt-in: craftdriver never sets it for you,
+and omitting it changes nothing. Steps 4–5 below are **not** craftdriver-opt-in
+the same way, though — `CHROME_BIN`, `FIREFOX_BIN`, `SE_CHROME_PATH`, and
+`SE_FIREFOX_PATH` are conventions other tools (Karma, Selenium Manager) already
+set in CI images and local environments for their own purposes. If one of
+those happens to already be exported in your environment, craftdriver will
+start forwarding it as of this version — a behavior change you didn't ask
+craftdriver for, even though you didn't touch any craftdriver config either.
+If you don't want that, set `CRAFTDRIVER_OFFLINE`-style pinning instead, or
+simply don't rely on those four var names for anything craftdriver-adjacent.
+
+| Step | Source |
+|---|---|
+| 1 | `browserPath` option in `Browser.launch()` |
+| 2 | `CRAFTDRIVER_CHROME_PATH` / `CRAFTDRIVER_FIREFOX_PATH` env var |
+| 3 | `CRAFTDRIVER_BROWSER_PATH` env var (generic fallback for either browser) |
+| 4 | `CHROME_BIN` / `FIREFOX_BIN` env var (common CI/tooling convention, e.g. Karma) |
+| 5 | `SE_CHROME_PATH` / `SE_FIREFOX_PATH` env var (Selenium Manager convention) |
+
+Each step is validated (the file must exist) before use; an invalid path falls
+through to the next step rather than being forwarded to the driver as-is (and
+logs a `[craftdriver]` note to stderr when it does, so a typo doesn't silently
+launch the wrong browser).
+
+`CRAFTDRIVER_BROWSER_PATH` (step 3) is forwarded verbatim regardless of
+whether the browser being launched is Chrome or Firefox — it's a single path,
+so it can only ever be correct for one of them. Don't set it in a process or
+CI job that launches both browsers; use the browser-specific `CRAFTDRIVER_CHROME_PATH`
+/ `CRAFTDRIVER_FIREFOX_PATH` instead.
+
+```typescript
+// Launch a custom Chromium build
+const browser = await Browser.launch({
+  browserName: 'chrome',
+  browserPath: '/opt/chromium-custom/chrome',
+});
+```
+
+```bash
+# Equivalent via env var — no code change needed
+CRAFTDRIVER_CHROME_PATH=/opt/chromium-custom/chrome npm test
+```
+
+If chromedriver itself also has to be auto-downloaded (no driver pinned
+anywhere in the chain above), its version is detected from *this* binary
+instead of probing for system Chrome — a custom Chromium build's version
+routinely doesn't match system Chrome, so using the right binary for version
+detection avoids downloading a mismatched chromedriver. Firefox has no
+equivalent concern: geckodriver's own download isn't gated on the Firefox
+version.
+
+Version detection runs the binary with `--version` and parses its output, the
+same way craftdriver already probes system Chrome/Firefox — so `browserPath`
+is supported for Chrome/Chromium and Firefox builds only. Anything that
+doesn't answer `--version` the way those browsers do (Electron apps and other
+Chromium embedders) is out of scope for now; point `CRAFTDRIVER_CHROMEDRIVER_PATH`
+at a pinned driver instead of relying on auto-detection in that case.
+
 ## Environment variables
 
 | Variable | Description | Default |
@@ -52,6 +116,9 @@ explicit config always wins, per the chain above).
 | `CRAFTDRIVER_CHROMEDRIVER_PATH` | Absolute path to a chromedriver binary | — |
 | `CRAFTDRIVER_GECKODRIVER_PATH` | Absolute path to a geckodriver binary | — |
 | `CRAFTDRIVER_DRIVER_PATH` | Generic fallback path (either browser) | — |
+| `CRAFTDRIVER_CHROME_PATH` | Absolute path to a Chrome/Chromium binary — see [Browser Binary Configuration](#browser-binary-configuration) | — |
+| `CRAFTDRIVER_FIREFOX_PATH` | Absolute path to a Firefox binary | — |
+| `CRAFTDRIVER_BROWSER_PATH` | Generic browser-binary fallback path (either browser) | — |
 | `CRAFTDRIVER_CACHE_DIR` | Directory for cached driver downloads | `~/.cache/craftdriver` |
 | `CRAFTDRIVER_OFFLINE` | Set to `1` to disable all network calls | — |
 | `CRAFTDRIVER_DRIVER_TTL` | Driver-resolution cache lifetime, in seconds (both browsers). `0` disables the cache | `86400` (24 h) |

--- a/docs/driver-configuration.md
+++ b/docs/driver-configuration.md
@@ -133,6 +133,20 @@ but the direction holds):
 
 Run it yourself with `npm run bench -- launch-critical-path`.
 
+A separate micro-benchmark (`tests/perf/driver-resolution.perf.ts`) isolates
+just the CI-provided driver directory step from the rest of the resolution
+chain — `resolveChromeDriver()` alone, cache isolated so both paths are
+measured cold:
+
+| Scenario | Time |
+|---|---|
+| `CHROMEWEBDRIVER` set (new) | ~0ms (an `fs.existsSync` check) |
+| PATH-probe + Chrome-version-detect fallback (old) | ~360ms |
+
+That's the cost every cold `Browser.launch()` used to pay once per process on
+a GitHub Actions runner before this step existed — now skipped entirely. Run
+it yourself with `npm run bench -- driver-resolution`.
+
 ### Browser startup flags (advanced, opt-in)
 
 craftdriver launches the browser with **no performance flags of its own** — it

--- a/docs/zero-config-drivers.md
+++ b/docs/zero-config-drivers.md
@@ -24,15 +24,24 @@ CraftDriver checks for the driver in this order:
 | ---- | ----------------------------------------------------------------------- |
 | 1    | Explicit `ChromeService` / `FirefoxService` configuration               |
 | 2    | Environment variables such as `CHROMEDRIVER_PATH` or `GECKODRIVER_PATH` |
-| 3    | Project-local binaries in `node_modules/.bin`                           |
-| 4    | Binaries already available on `PATH`                                    |
-| 5    | Auto-resolved and cached driver matching the installed browser          |
+| 3    | Known CI-provided driver directories (e.g. GitHub Actions' `CHROMEWEBDRIVER` / `GECKOWEBDRIVER`) |
+| 4    | Project-local binaries in `node_modules/.bin`                           |
+| 5    | Binaries already available on `PATH`                                    |
+| 6    | Auto-resolved and cached driver matching the installed browser          |
 
 If a browser update leaves a cached driver stale, CraftDriver retries once with a refreshed driver instead of making you clear the cache manually.
 
 ## CI Friendly
 
-The default setup works well on CI runners that already include Chrome or Firefox. For stricter environments, you can pin the driver path or run offline:
+The default setup works well on CI runners that already include Chrome or
+Firefox. On **GitHub Actions** specifically, craftdriver auto-detects the
+runner's own pre-installed, version-matched driver out of the box (via
+`CHROMEWEBDRIVER` / `GECKOWEBDRIVER`) — no configuration needed, and it's
+faster than the fallback probes since it skips version detection entirely (see
+[Driver Configuration → CI platform detection](./driver-configuration.md#ci-platform-detection)).
+
+For platforms without built-in detection, or to pin a driver other than the
+runner's default, set the path manually:
 
 ```bash
 CRAFTDRIVER_CHROMEDRIVER_PATH=/usr/bin/chromedriver npm test

--- a/docs/zero-config-drivers.md
+++ b/docs/zero-config-drivers.md
@@ -57,5 +57,8 @@ Manual configuration is useful when:
 - network access is blocked
 - you need custom driver logging
 - you want to avoid any version detection during launch
+- you're launching a non-default Chrome/Chromium/Firefox build via
+  `browserPath` / `CRAFTDRIVER_CHROME_PATH` — see
+  [Driver Configuration → Browser Binary Configuration](./driver-configuration.md#browser-binary-configuration)
 
 See [Driver Configuration](./driver-configuration.md) for the full reference.

--- a/src/lib/browser.ts
+++ b/src/lib/browser.ts
@@ -1,6 +1,7 @@
 import { Builder } from './builder.js';
 import { ChromeService } from './chrome.js';
 import { FirefoxService } from './firefox.js';
+import { resolveBrowserBinaryPath } from './driverManager.js';
 import { Driver } from './driver.js';
 import { By } from './by.js';
 import { Condition, WaitOptions, until } from './wait.js';
@@ -172,6 +173,28 @@ export interface LaunchOptions {
    * `FirefoxService`.
    */
   args?: string[];
+  /**
+   * A custom **browser** binary to launch — Chrome, Chromium, or Firefox.
+   * Distinct from `chromeService`/`firefoxService`'s `binaryPath`, which names
+   * the *driver* (chromedriver/geckodriver), not the browser.
+   *
+   * When omitted, craftdriver resolves it from (first match wins):
+   *   1. `CRAFTDRIVER_CHROME_PATH` / `CRAFTDRIVER_FIREFOX_PATH` env var
+   *   2. `CRAFTDRIVER_BROWSER_PATH` env var (generic fallback — forwarded as-is
+   *      regardless of browser, so avoid it when launching both in one job)
+   *   3. `CHROME_BIN` / `FIREFOX_BIN` env var (common CI convention)
+   *   4. `SE_CHROME_PATH` / `SE_FIREFOX_PATH` env var (Selenium Manager convention)
+   *
+   * This option itself is opt-in, but steps 2–4 read ambient env vars other
+   * tools (Karma, Selenium Manager) may already export for their own
+   * purposes — if one happens to be set, craftdriver forwards it even though
+   * you never touched craftdriver config. If none resolve, craftdriver
+   * forwards nothing and chromedriver/geckodriver fall back to their own
+   * built-in browser discovery. An invalid candidate at any step logs a
+   * `[craftdriver]` note to stderr and falls through rather than failing
+   * silently. See "Browser Binary Configuration" in docs/driver-configuration.md.
+   */
+  browserPath?: string;
 }
 
 /**
@@ -410,6 +433,13 @@ export class Browser {
     );
     await fs.mkdir(downloadsDir, { recursive: true });
 
+    // Custom browser binary (Chrome/Chromium/Firefox). When unresolved,
+    // nothing is forwarded and the driver uses its own built-in browser
+    // discovery — but see resolveBrowserBinaryPath's doc: some of the env
+    // vars in this chain aren't craftdriver-opt-in, they're ambient
+    // conventions other tools may already have set.
+    const browserPath = resolveBrowserBinaryPath(isChromeFamily ? 'chrome' : 'firefox', options.browserPath);
+
     let caps: Capabilities = {};
 
     if (isChromeFamily) {
@@ -421,6 +451,7 @@ export class Browser {
           'safebrowsing.enabled': true,
         },
       };
+      if (browserPath) chromeOptions.binary = browserPath;
 
       // Add mobile emulation if specified
       if (options.mobileEmulation) {
@@ -468,6 +499,7 @@ export class Browser {
             'application/octet-stream,application/pdf,text/plain,text/csv,application/zip',
           'pdfjs.disabled': true,
         },
+        ...(browserPath ? { binary: browserPath } : {}),
       };
     }
 
@@ -486,7 +518,10 @@ export class Browser {
     const builder = new Builder().forBrowser(name);
     let driverService: ChromeService | FirefoxService;
     if (isChromeFamily) {
-      driverService = options.chromeService ?? new ChromeService();
+      // Only thread browserPath into a default ChromeService — a
+      // caller-supplied one is expected to already pin what it needs (same
+      // reasoning as explicit config always winning over auto-detection).
+      driverService = options.chromeService ?? new ChromeService({ browserPath });
       builder.setChromeService(driverService as ChromeService);
     } else {
       driverService = options.firefoxService ?? new FirefoxService();

--- a/src/lib/chrome.ts
+++ b/src/lib/chrome.ts
@@ -12,13 +12,24 @@ export type ChromeServiceOptions = Omit<DriverServiceOptions, 'command'> & {
    *   5. Detect system Chrome version → download matching chromedriver from CfT
    */
   binaryPath?: string;
+  /**
+   * A custom **browser** binary — Chrome or Chromium — distinct from
+   * `binaryPath` above (which names the *driver*). Not sent to the driver
+   * directly; used only so that if `binaryPath` is omitted and chromedriver
+   * has to be auto-downloaded, its version is detected from this binary
+   * instead of probing for system Chrome. To actually launch this binary,
+   * also set `LaunchOptions.browserPath` (or the `CRAFTDRIVER_CHROME_PATH`
+   * / `CHROME_BIN` env vars) — see docs/driver-configuration.md.
+   */
+  browserPath?: string;
 };
 
 export class ChromeService extends DriverService {
   private readonly binaryPath: string | undefined;
+  private readonly browserPath: string | undefined;
 
   constructor(options: ChromeServiceOptions = {}) {
-    const { binaryPath, ...rest } = options;
+    const { binaryPath, browserPath, ...rest } = options;
     // Pass a placeholder command; the real path is resolved asynchronously in start().
     super({
       command: binaryPath ?? 'chromedriver',
@@ -27,11 +38,12 @@ export class ChromeService extends DriverService {
       ...rest,
     });
     this.binaryPath = binaryPath;
+    this.browserPath = browserPath;
   }
 
   async start(): Promise<void> {
     if (this.proc) return;
-    this.opts.command = await resolveChromeDriver({ binaryPath: this.binaryPath });
+    this.opts.command = await resolveChromeDriver({ binaryPath: this.binaryPath, browserPath: this.browserPath });
     await super.start();
   }
 }

--- a/src/lib/chrome.ts
+++ b/src/lib/chrome.ts
@@ -6,9 +6,10 @@ export type ChromeServiceOptions = Omit<DriverServiceOptions, 'command'> & {
    * Absolute path to a `chromedriver` binary.
    * When omitted, craftdriver resolves the driver automatically:
    *   1. CRAFTDRIVER_DRIVER_PATH / CHROMEDRIVER_PATH / SE_CHROMEDRIVER env vars
-   *   2. node_modules/.bin/chromedriver (if chromedriver npm package is installed)
-   *   3. chromedriver on PATH
-   *   4. Detect system Chrome version → download matching chromedriver from CfT
+   *   2. Known CI-provided driver directories (e.g. GitHub Actions' CHROMEWEBDRIVER)
+   *   3. node_modules/.bin/chromedriver (if chromedriver npm package is installed)
+   *   4. chromedriver on PATH
+   *   5. Detect system Chrome version → download matching chromedriver from CfT
    */
   binaryPath?: string;
 };

--- a/src/lib/driverManager.ts
+++ b/src/lib/driverManager.ts
@@ -15,6 +15,10 @@
  * Only the driver binary is downloaded by default, never the browser itself.
  * This avoids CfT's OS-dependency problems on lean Linux containers.
  * See research/driver-manager.md for the full strategy.
+ *
+ * A separate, independent chain resolves a custom **browser** binary (Chrome/
+ * Chromium/Firefox) — see `resolveBrowserBinaryPath()` below. It's opt-in
+ * only: nothing resolving there changes any of the above.
  */
 
 import fs from 'fs';
@@ -489,9 +493,64 @@ async function downloadGeckodriver(): Promise<string> {
 const CHROME_CI_DIR_ENV_VARS = ['CHROMEWEBDRIVER'];   // GitHub Actions
 const GECKO_CI_DIR_ENV_VARS  = ['GECKOWEBDRIVER'];    // GitHub Actions
 
+/**
+ * Resolves a custom **browser** binary (Chrome/Chromium/Firefox) — distinct
+ * from `resolveChromeDriver`/`resolveFirefoxDriver`, which resolve the
+ * *driver* (chromedriver/geckodriver). Returns `undefined` when
+ * nothing resolves, in which case the caller forwards nothing and
+ * chromedriver/geckodriver fall back to their own built-in browser discovery
+ * (craftdriver's zero-config default, unchanged).
+ *
+ * Resolution chain (first match wins), each step validated with
+ * `fs.existsSync` — an invalid path falls through rather than being forwarded:
+ *   1. `explicitPath` (e.g. LaunchOptions.browserPath)
+ *   2. CRAFTDRIVER_CHROME_PATH / CRAFTDRIVER_FIREFOX_PATH (browser-specific)
+ *   3. CRAFTDRIVER_BROWSER_PATH (generic fallback, either browser)
+ *   4. Legacy/compatible env vars: CHROME_BIN / FIREFOX_BIN (community
+ *      convention), SE_CHROME_PATH / SE_FIREFOX_PATH (Selenium Manager)
+ */
+export function resolveBrowserBinaryPath(
+  kind: 'chrome' | 'firefox',
+  explicitPath?: string,
+): string | undefined {
+  if (explicitPath) {
+    if (fs.existsSync(explicitPath)) return explicitPath;
+    // A candidate was actually supplied here, so a silent fallthrough would
+    // hide a typo behind a browser that quietly launches from somewhere else
+    // entirely. Everything below the auto-download path already announces
+    // itself the same way (see downloadChromedriver/downloadGeckodriver).
+    process.stderr.write(
+      `[craftdriver] browserPath "${explicitPath}" does not exist; falling back to the next resolution step.\n`,
+    );
+  }
+
+  const specificEnvVar = kind === 'chrome' ? 'CRAFTDRIVER_CHROME_PATH' : 'CRAFTDRIVER_FIREFOX_PATH';
+  const legacyBinEnvVar = kind === 'chrome' ? 'CHROME_BIN' : 'FIREFOX_BIN';
+  const legacySeEnvVar = kind === 'chrome' ? 'SE_CHROME_PATH' : 'SE_FIREFOX_PATH';
+
+  for (const envVar of [specificEnvVar, 'CRAFTDRIVER_BROWSER_PATH', legacyBinEnvVar, legacySeEnvVar]) {
+    const p = process.env[envVar];
+    if (!p) continue;
+    if (fs.existsSync(p)) return p;
+    process.stderr.write(
+      `[craftdriver] ${envVar}="${p}" does not exist; falling back to the next resolution step.\n`,
+    );
+  }
+
+  return undefined;
+}
+
 /** Resolves the path to a chromedriver binary, downloading if necessary. */
 export async function resolveChromeDriver(options?: {
   binaryPath?: string;
+  /**
+   * A custom browser binary (see {@link resolveBrowserBinaryPath}). When the
+   * driver itself has to be auto-downloaded (step 8), its version is detected
+   * from *this* binary instead of the system Chrome candidate list — so a
+   * custom Chromium build (whose version routinely doesn't match system
+   * Chrome) gets a matching chromedriver, not the wrong one.
+   */
+  browserPath?: string;
 }): Promise<string> {
   // 1. Explicit constructor argument.
   if (options?.binaryPath && fs.existsSync(options.binaryPath)) {
@@ -557,15 +616,25 @@ export async function resolveChromeDriver(options?: {
     );
   }
 
-  // 8. Detect system Chrome + download matching driver from CfT, then record
-  //    the result in the auto-resolution cache read at step 4.
+  // 8. Detect the browser + download a matching driver from CfT, then record
+  //    the result in the auto-resolution cache read at step 4. If a custom
+  //    browser binary was given, detect its version directly instead of
+  //    probing the system Chrome candidate list (see resolveChromeDriver's
+  //    `browserPath` option doc). This assumes the binary answers `--version`
+  //    the way Chrome/Chromium does — untested against anything that doesn't
+  //    (e.g. Electron), so `browserPath` is documented as Chrome/Chromium-only
+  //    for now.
   const p = os.platform() as SupportedPlatform;
-  const candidates = CHROME_CANDIDATES[p] ?? ['google-chrome'];
+  const candidates = options?.browserPath ? [options.browserPath] : (CHROME_CANDIDATES[p] ?? ['google-chrome']);
   const detected = detectBrowserVersion(candidates);
   if (!detected) {
     throw new Error(
-      'Could not detect a system Chrome or Chromium installation.\n' +
-      'Install Chrome, or set CRAFTDRIVER_DRIVER_PATH to a local chromedriver binary.',
+      options?.browserPath
+        ? `Could not read a Chrome/Chromium version from browserPath "${options.browserPath}" ` +
+          '(it did not respond to --version the way Chrome/Chromium does).\n' +
+          'Set CRAFTDRIVER_CHROMEDRIVER_PATH to a chromedriver binary that matches it instead of relying on auto-detection.'
+        : 'Could not detect a system Chrome or Chromium installation.\n' +
+          'Install Chrome, or set CRAFTDRIVER_DRIVER_PATH to a local chromedriver binary.',
     );
   }
   const driverPath = await downloadChromedriver(detected.version);

--- a/src/lib/driverManager.ts
+++ b/src/lib/driverManager.ts
@@ -5,6 +5,8 @@
  *   1. options.binaryPath (explicit)
  *   2. CRAFTDRIVER_DRIVER_PATH
  *   3. Legacy env vars (CHROMEDRIVER_PATH, SE_CHROMEDRIVER, etc.)
+ *   3.5. Known CI-provided driver directories (e.g. GitHub Actions'
+ *        CHROMEWEBDRIVER / GECKOWEBDRIVER)
  *   4. node_modules/.bin/chromedriver|geckodriver
  *   5. PATH probe
  *   [CRAFTDRIVER_OFFLINE → throw here if no match yet]
@@ -478,6 +480,15 @@ async function downloadGeckodriver(): Promise<string> {
 
 // ─── Public API ───────────────────────────────────────────────────────────────
 
+// CI platforms that pre-install a version-matched driver and publish its
+// directory via an env var. Not craftdriver-specific — these are the
+// platform's own convention — so this step ranks below explicit config
+// (steps 1-3) and only fills a gap when nothing more specific was set.
+// Confirmed present with matching semantics on GitHub Actions' Ubuntu, macOS,
+// and Windows runner images (see actions/runner-images per-image READMEs).
+const CHROME_CI_DIR_ENV_VARS = ['CHROMEWEBDRIVER'];   // GitHub Actions
+const GECKO_CI_DIR_ENV_VARS  = ['GECKOWEBDRIVER'];    // GitHub Actions
+
 /** Resolves the path to a chromedriver binary, downloading if necessary. */
 export async function resolveChromeDriver(options?: {
   binaryPath?: string;
@@ -497,6 +508,19 @@ export async function resolveChromeDriver(options?: {
   for (const envVar of ['CHROMEDRIVER_PATH', 'SE_CHROMEDRIVER']) {
     const p = process.env[envVar];
     if (p && fs.existsSync(p)) return p;
+  }
+
+  // 3.5. Known CI-provided driver directories (e.g. GitHub Actions'
+  //      CHROMEWEBDRIVER). Cheaper than a cache read (fs.existsSync) and a
+  //      stronger signal than anything below: the CI platform vendor
+  //      guarantees this driver matches the pre-installed browser version.
+  //      Not cached — it's already as cheap as a cache read, so caching it
+  //      would only add stale-path risk for no benefit.
+  for (const envVar of CHROME_CI_DIR_ENV_VARS) {
+    const dir = process.env[envVar];
+    if (!dir) continue;
+    const candidate = path.join(dir, driverBinName());
+    if (fs.existsSync(candidate)) return candidate;
   }
 
   // 4. Auto-resolution cache. Once we've auto-resolved a chromedriver (step 7
@@ -572,6 +596,16 @@ export async function resolveFirefoxDriver(options?: {
     if (p && fs.existsSync(p)) return p;
   }
 
+  // 3.5. Known CI-provided driver directories (e.g. GitHub Actions'
+  //      GECKOWEBDRIVER). See resolveChromeDriver's equivalent step for why
+  //      this ranks here and isn't cached.
+  for (const envVar of GECKO_CI_DIR_ENV_VARS) {
+    const dir = process.env[envVar];
+    if (!dir) continue;
+    const candidate = path.join(dir, geckoBinName());
+    if (fs.existsSync(candidate)) return candidate;
+  }
+
   // 4. Auto-resolution cache. Once geckodriver has been auto-resolved (step 8
   //    below writes this record), reuse it for a TTL window instead of probing
   //    PATH (a blocking `which` spawn) and re-detecting Firefox on every
@@ -590,8 +624,11 @@ export async function resolveFirefoxDriver(options?: {
   );
   if (fs.existsSync(localBin)) return localBin;
 
-  // 6. PATH probe.
-  if (commandOnPath('geckodriver')) return 'geckodriver';
+  // 6. PATH probe (skipped when CRAFTDRIVER_SKIP_PATH_PROBE is set, e.g. in
+  //    integration tests that need to exercise the auto-download path even on
+  //    systems where geckodriver is already installed). Mirrors
+  //    resolveChromeDriver's equivalent step.
+  if (!process.env.CRAFTDRIVER_SKIP_PATH_PROBE && commandOnPath('geckodriver')) return 'geckodriver';
 
   // 7. Offline guard.
   if (process.env.CRAFTDRIVER_OFFLINE) {

--- a/src/lib/firefox.ts
+++ b/src/lib/firefox.ts
@@ -7,9 +7,10 @@ export type FirefoxServiceOptions = Omit<DriverServiceOptions, 'command'> & {
    * Absolute path to a `geckodriver` binary.
    * When omitted, craftdriver resolves the driver automatically:
    *   1. CRAFTDRIVER_DRIVER_PATH / GECKODRIVER_PATH / GECKODRIVER_FILEPATH / SE_GECKODRIVER env vars
-   *   2. node_modules/.bin/geckodriver (if geckodriver npm package is installed)
-   *   3. geckodriver on PATH
-   *   4. Download latest geckodriver from GitHub releases
+   *   2. Known CI-provided driver directories (e.g. GitHub Actions' GECKOWEBDRIVER)
+   *   3. node_modules/.bin/geckodriver (if geckodriver npm package is installed)
+   *   4. geckodriver on PATH
+   *   5. Download latest geckodriver from GitHub releases
    */
   binaryPath?: string;
 };

--- a/tests/browser-binary-path.test.ts
+++ b/tests/browser-binary-path.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Tests for resolveBrowserBinaryPath() — the browser-binary resolution chain
+ * (Chrome/Chromium/Firefox), independent of and opt-in relative to the
+ * existing driver-binary chain in driverManager.ts.
+ */
+
+import { describe, it, beforeEach, afterEach, expect } from 'vitest';
+import { resolveBrowserBinaryPath } from '../src/lib/driverManager';
+import { Browser } from '../src';
+import { EXAMPLES_BASE_URL } from './utils';
+import path from 'path';
+import os from 'os';
+import fs from 'fs';
+import { spawnSync } from 'child_process';
+
+/** Remove a list of keys from process.env, returning a restore function. */
+function unsetEnvVars(keys: string[]): () => void {
+  const saved: Record<string, string | undefined> = {};
+  for (const key of keys) {
+    saved[key] = process.env[key];
+    delete process.env[key];
+  }
+  return () => {
+    for (const key of keys) {
+      if (saved[key] === undefined) delete process.env[key];
+      else process.env[key] = saved[key];
+    }
+  };
+}
+
+const BROWSER_PATH_ENV_VARS = [
+  'CRAFTDRIVER_CHROME_PATH',
+  'CRAFTDRIVER_FIREFOX_PATH',
+  'CRAFTDRIVER_BROWSER_PATH',
+  'CHROME_BIN',
+  'FIREFOX_BIN',
+  'SE_CHROME_PATH',
+  'SE_FIREFOX_PATH',
+];
+
+describe('resolveBrowserBinaryPath()', () => {
+  const testRoot = path.join(os.tmpdir(), `craftdriver-browserpath-${process.pid}`);
+  let restoreEnv = () => {};
+
+  beforeEach(() => {
+    fs.rmSync(testRoot, { recursive: true, force: true });
+    fs.mkdirSync(testRoot, { recursive: true });
+    restoreEnv = unsetEnvVars(BROWSER_PATH_ENV_VARS);
+  });
+
+  afterEach(() => {
+    restoreEnv?.();
+    fs.rmSync(testRoot, { recursive: true, force: true });
+  });
+
+  function touch(name: string): string {
+    const p = path.join(testRoot, name);
+    fs.writeFileSync(p, '');
+    return p;
+  }
+
+  it('returns undefined when nothing resolves', () => {
+    expect(resolveBrowserBinaryPath('chrome')).toBeUndefined();
+    expect(resolveBrowserBinaryPath('firefox')).toBeUndefined();
+  });
+
+  it('resolves the explicit argument first', () => {
+    const explicit = touch('explicit-chrome');
+    process.env.CRAFTDRIVER_CHROME_PATH = touch('env-chrome');
+    expect(resolveBrowserBinaryPath('chrome', explicit)).toBe(explicit);
+  });
+
+  it('falls through an invalid explicit argument to the env chain', () => {
+    const envPath = touch('env-chrome');
+    process.env.CRAFTDRIVER_CHROME_PATH = envPath;
+    expect(resolveBrowserBinaryPath('chrome', path.join(testRoot, 'does-not-exist'))).toBe(envPath);
+  });
+
+  it('prefers CRAFTDRIVER_CHROME_PATH over CRAFTDRIVER_BROWSER_PATH', () => {
+    process.env.CRAFTDRIVER_CHROME_PATH = touch('specific');
+    process.env.CRAFTDRIVER_BROWSER_PATH = touch('generic');
+    expect(resolveBrowserBinaryPath('chrome')).toBe(process.env.CRAFTDRIVER_CHROME_PATH);
+  });
+
+  it('prefers CRAFTDRIVER_BROWSER_PATH over CHROME_BIN', () => {
+    process.env.CRAFTDRIVER_BROWSER_PATH = touch('generic');
+    process.env.CHROME_BIN = touch('chrome-bin');
+    expect(resolveBrowserBinaryPath('chrome')).toBe(process.env.CRAFTDRIVER_BROWSER_PATH);
+  });
+
+  it('prefers CHROME_BIN over SE_CHROME_PATH', () => {
+    process.env.CHROME_BIN = touch('chrome-bin');
+    process.env.SE_CHROME_PATH = touch('se-chrome');
+    expect(resolveBrowserBinaryPath('chrome')).toBe(process.env.CHROME_BIN);
+  });
+
+  it('falls back to SE_CHROME_PATH when nothing else is set', () => {
+    process.env.SE_CHROME_PATH = touch('se-chrome');
+    expect(resolveBrowserBinaryPath('chrome')).toBe(process.env.SE_CHROME_PATH);
+  });
+
+  it('skips an env var pointing at a nonexistent file', () => {
+    process.env.CRAFTDRIVER_CHROME_PATH = path.join(testRoot, 'does-not-exist');
+    process.env.CHROME_BIN = touch('chrome-bin');
+    expect(resolveBrowserBinaryPath('chrome')).toBe(process.env.CHROME_BIN);
+  });
+
+  it('resolves Firefox vars independently of Chrome vars', () => {
+    process.env.CRAFTDRIVER_CHROME_PATH = touch('chrome');
+    process.env.CRAFTDRIVER_FIREFOX_PATH = touch('firefox');
+    expect(resolveBrowserBinaryPath('firefox')).toBe(process.env.CRAFTDRIVER_FIREFOX_PATH);
+    expect(resolveBrowserBinaryPath('chrome')).toBe(process.env.CRAFTDRIVER_CHROME_PATH);
+  });
+});
+
+/** Best-effort discovery of a real, already-installed Chrome/Chromium binary
+ *  on this machine — deliberately independent of driverManager's own
+ *  CHROME_CANDIDATES list, so the test doesn't just check its own homework. */
+function findSystemChromeBinary(): string | undefined {
+  const platform = os.platform();
+  if (platform === 'darwin') {
+    return [
+      '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+      '/Applications/Chromium.app/Contents/MacOS/Chromium',
+    ].find((p) => fs.existsSync(p));
+  }
+  if (platform === 'win32') {
+    return [
+      'C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe',
+      'C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe',
+    ].find((p) => fs.existsSync(p));
+  }
+  for (const cmd of ['google-chrome', 'google-chrome-stable', 'chromium', 'chromium-browser']) {
+    const r = spawnSync('which', [cmd], { encoding: 'utf-8' });
+    if (r.status === 0 && r.stdout.trim()) return r.stdout.trim();
+  }
+  return undefined;
+}
+
+describe('Browser.launch() with a custom browserPath', () => {
+  const systemChrome = findSystemChromeBinary();
+
+  it.skipIf(!systemChrome)(
+    'launches successfully when browserPath points at a real Chrome binary',
+    async () => {
+      const browser = await Browser.launch({ browserName: 'chrome', browserPath: systemChrome });
+      try {
+        await browser.navigateTo(`${EXAMPLES_BASE_URL}/login.html`);
+        await browser.fill('#username', 'testuser');
+        await browser.fill('#password', 'secret');
+        await browser.click('#submit');
+        await browser.find('#result').expect().toContainText('Welcome back');
+      } finally {
+        await browser.quit();
+      }
+    },
+    60_000,
+  );
+});

--- a/tests/chrome-smoke.test.ts
+++ b/tests/chrome-smoke.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Chrome smoke test — twin of tests/firefox-smoke.test.ts.
+ *
+ * Run with: npm test -- tests/chrome-smoke.test.ts
+ *
+ * Validates that the ChromeService + Builder branch can launch chromedriver,
+ * negotiate a BiDi WebSocket, navigate, find/click/fill elements, and
+ * evaluate JS. Kept as a single small file so it can run in isolation as a
+ * fast cross-platform confidence check (see the `cross-platform-smoke` CI
+ * job in .github/workflows/ci.yml) without running the full suite.
+ */
+import { describe, it, expect } from 'vitest';
+import { Browser } from '../src';
+import { EXAMPLES_BASE_URL, BROWSER_NAME } from './utils';
+
+describe.runIf(BROWSER_NAME === 'chrome')('Chrome smoke', () => {
+  it('launches Chrome, enables BiDi, and runs the basics', async () => {
+    const browser = await Browser.launch({ browserName: 'chrome' });
+    try {
+      expect(browser.isBiDiEnabled()).toBe(true);
+
+      await browser.navigateTo(`${EXAMPLES_BASE_URL}/login.html`);
+
+      await browser.fill('#username', 'testuser');
+      await browser.fill('#password', 'secret');
+      await browser.click('#submit');
+
+      await browser.find('#result').expect().toContainText('Welcome back');
+
+      const title: string = await browser.evaluate(() => document.title);
+      expect(typeof title).toBe('string');
+      expect(title.length).toBeGreaterThan(0);
+    } finally {
+      await browser.quit();
+    }
+  });
+});

--- a/tests/driver-manager-ci-detection.test.ts
+++ b/tests/driver-manager-ci-detection.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Regression tests for the CI-provided driver directory step in
+ * resolveChromeDriver() / resolveFirefoxDriver() (step 3.5 of the resolution
+ * chain — see driverManager.ts's top-of-file comment).
+ *
+ * GitHub Actions runners pre-install a version-matched driver and publish its
+ * directory via CHROMEWEBDRIVER / GECKOWEBDRIVER. This step must win over the
+ * auto-resolution cache, npm-local binary, PATH probe, and download, but must
+ * never override explicit craftdriver config.
+ */
+
+import { describe, it, beforeEach, afterEach, expect } from 'vitest';
+import { resolveChromeDriver, resolveFirefoxDriver } from '../src/lib/driverManager';
+import path from 'path';
+import os from 'os';
+import fs from 'fs';
+
+/** Remove a list of keys from process.env, returning a restore function. */
+function unsetEnvVars(keys: string[]): () => void {
+  const saved: Record<string, string | undefined> = {};
+  for (const key of keys) {
+    saved[key] = process.env[key];
+    delete process.env[key];
+  }
+  return () => {
+    for (const key of keys) {
+      if (saved[key] === undefined) delete process.env[key];
+      else process.env[key] = saved[key];
+    }
+  };
+}
+
+const chromeBinName = os.platform() === 'win32' ? 'chromedriver.exe' : 'chromedriver';
+const geckoBinName = os.platform() === 'win32' ? 'geckodriver.exe' : 'geckodriver';
+
+/** Create a fake, non-empty, executable file at `dir/binName`. */
+function writeFakeDriver(dir: string, binName: string): string {
+  fs.mkdirSync(dir, { recursive: true });
+  const bin = path.join(dir, binName);
+  fs.writeFileSync(bin, '#!/bin/sh\necho fake driver\n');
+  if (os.platform() !== 'win32') fs.chmodSync(bin, 0o755);
+  return bin;
+}
+
+describe('driver manager — CI-provided driver directories', () => {
+  const testRoot = path.join(os.tmpdir(), `craftdriver-ci-detect-${process.pid}`);
+  const testCacheDir = path.join(testRoot, 'cache');
+  let restoreEnv = () => {};
+
+  beforeEach(() => {
+    fs.rmSync(testRoot, { recursive: true, force: true });
+
+    restoreEnv = unsetEnvVars([
+      'CRAFTDRIVER_CHROMEDRIVER_PATH',
+      'CRAFTDRIVER_GECKODRIVER_PATH',
+      'CRAFTDRIVER_DRIVER_PATH',
+      'CRAFTDRIVER_CACHE_DIR',
+      'CRAFTDRIVER_OFFLINE',
+      'CHROMEDRIVER_PATH',
+      'SE_CHROMEDRIVER',
+      'GECKODRIVER_PATH',
+      'GECKODRIVER_FILEPATH',
+      'SE_GECKODRIVER',
+      'CRAFTDRIVER_SKIP_PATH_PROBE',
+      'CHROMEWEBDRIVER',
+      'GECKOWEBDRIVER',
+    ]);
+
+    // Skip the PATH probe so a chromedriver/geckodriver already on this
+    // machine's PATH can't mask a resolution-order bug as a pass.
+    process.env.CRAFTDRIVER_SKIP_PATH_PROBE = '1';
+    process.env.CRAFTDRIVER_CACHE_DIR = testCacheDir;
+  });
+
+  afterEach(() => {
+    restoreEnv?.();
+    fs.rmSync(testRoot, { recursive: true, force: true });
+  });
+
+  describe('resolveChromeDriver()', () => {
+    it('resolves the driver from CHROMEWEBDRIVER when set to a directory containing it', async () => {
+      // Placed under the isolated test root, so it can only be found via
+      // CHROMEWEBDRIVER — never via PATH, npm-local, cache, or download.
+      const dir = path.join(testRoot, 'chromewebdriver');
+      const bin = writeFakeDriver(dir, chromeBinName);
+      process.env.CHROMEWEBDRIVER = dir;
+
+      const resolved = await resolveChromeDriver();
+      expect(resolved).toBe(bin);
+
+      // Must not have written to the auto-resolution cache.
+      expect(fs.existsSync(path.join(testCacheDir, 'metadata.json'))).toBe(false);
+    });
+
+    it('prefers explicit CRAFTDRIVER_CHROMEDRIVER_PATH over CHROMEWEBDRIVER', async () => {
+      const ciDir = path.join(testRoot, 'chromewebdriver');
+      writeFakeDriver(ciDir, chromeBinName);
+      process.env.CHROMEWEBDRIVER = ciDir;
+
+      const explicitBin = writeFakeDriver(path.join(testRoot, 'explicit'), chromeBinName);
+      process.env.CRAFTDRIVER_CHROMEDRIVER_PATH = explicitBin;
+
+      const resolved = await resolveChromeDriver();
+      expect(resolved).toBe(explicitBin);
+    });
+
+    it('falls through when CHROMEWEBDRIVER points at a nonexistent directory', async () => {
+      process.env.CHROMEWEBDRIVER = path.join(testRoot, 'does-not-exist');
+      // Force a fast, deterministic failure further down the chain instead of
+      // a real network download, so this test only proves the bad CI var
+      // didn't throw or get misused — not that the rest of the chain works.
+      process.env.CRAFTDRIVER_OFFLINE = '1';
+
+      await expect(resolveChromeDriver()).rejects.toThrow(/no chromedriver was found/i);
+    });
+
+    it('is unaffected when CHROMEWEBDRIVER is unset', async () => {
+      delete process.env.CHROMEWEBDRIVER;
+      const localBin = writeFakeDriver(path.join(testRoot, 'explicit'), chromeBinName);
+      process.env.CRAFTDRIVER_CHROMEDRIVER_PATH = localBin;
+
+      const resolved = await resolveChromeDriver();
+      expect(resolved).toBe(localBin);
+    });
+  });
+
+  describe('resolveFirefoxDriver()', () => {
+    it('resolves the driver from GECKOWEBDRIVER when set to a directory containing it', async () => {
+      const dir = path.join(testRoot, 'geckowebdriver');
+      const bin = writeFakeDriver(dir, geckoBinName);
+      process.env.GECKOWEBDRIVER = dir;
+
+      const resolved = await resolveFirefoxDriver();
+      expect(resolved).toBe(bin);
+
+      expect(fs.existsSync(path.join(testCacheDir, 'metadata.json'))).toBe(false);
+    });
+
+    it('prefers explicit CRAFTDRIVER_GECKODRIVER_PATH over GECKOWEBDRIVER', async () => {
+      const ciDir = path.join(testRoot, 'geckowebdriver');
+      writeFakeDriver(ciDir, geckoBinName);
+      process.env.GECKOWEBDRIVER = ciDir;
+
+      const explicitBin = writeFakeDriver(path.join(testRoot, 'explicit'), geckoBinName);
+      process.env.CRAFTDRIVER_GECKODRIVER_PATH = explicitBin;
+
+      const resolved = await resolveFirefoxDriver();
+      expect(resolved).toBe(explicitBin);
+    });
+
+    it('falls through when GECKOWEBDRIVER points at a nonexistent directory', async () => {
+      process.env.GECKOWEBDRIVER = path.join(testRoot, 'does-not-exist');
+      process.env.CRAFTDRIVER_OFFLINE = '1';
+
+      await expect(resolveFirefoxDriver()).rejects.toThrow(/no geckodriver was found/i);
+    });
+
+    it('is unaffected when GECKOWEBDRIVER is unset', async () => {
+      delete process.env.GECKOWEBDRIVER;
+      const localBin = writeFakeDriver(path.join(testRoot, 'explicit'), geckoBinName);
+      process.env.CRAFTDRIVER_GECKODRIVER_PATH = localBin;
+
+      const resolved = await resolveFirefoxDriver();
+      expect(resolved).toBe(localBin);
+    });
+  });
+});

--- a/tests/driver-manager.test.ts
+++ b/tests/driver-manager.test.ts
@@ -48,7 +48,12 @@ describe('driver manager — auto-download integration', () => {
     // Ensure the test cache starts empty so we exercise the download path.
     fs.rmSync(testCacheDir, { recursive: true, force: true });
 
-    // Unset every env var that could short-circuit auto-resolution.
+    // Unset every env var that could short-circuit auto-resolution, including
+    // CI-provided driver directories (CHROMEWEBDRIVER/GECKOWEBDRIVER) — GitHub
+    // Actions runners set these natively, and step 3.5 in driverManager.ts
+    // ranks them above the auto-download path this test exercises, so leaving
+    // them set makes this "downloads chromedriver" test pass without ever
+    // downloading anything on CI.
     restoreEnv = unsetEnvVars([
       'CRAFTDRIVER_CHROMEDRIVER_PATH',
       'CRAFTDRIVER_GECKODRIVER_PATH',
@@ -58,6 +63,8 @@ describe('driver manager — auto-download integration', () => {
       'CHROMEDRIVER_PATH',
       'SE_CHROMEDRIVER',
       'CRAFTDRIVER_SKIP_PATH_PROBE',
+      'CHROMEWEBDRIVER',
+      'GECKOWEBDRIVER',
     ]);
 
     // Skip the PATH probe so pre-installed chromedriver on CI runners

--- a/tests/perf/driver-resolution.perf.ts
+++ b/tests/perf/driver-resolution.perf.ts
@@ -1,0 +1,138 @@
+/**
+ * Micro-benchmark backing the CI-provided driver directory step (step 3.5 in
+ * driverManager.ts's resolution chain — CHROMEWEBDRIVER / GECKOWEBDRIVER).
+ *
+ * Compares resolveChromeDriver() timing:
+ *   - "ci-dir":    CHROMEWEBDRIVER set to a directory already containing the
+ *                  driver — the new fast path (an fs.existsSync check).
+ *   - "fallback":  the pre-existing cold-cache path this step used to force
+ *                  every launch through on a fresh CI job: PATH probe (miss)
+ *                  + Chrome-version detection, both blocking spawnSync calls.
+ *
+ * The exact driver version is pre-copied from this machine's real
+ * ~/.cache/craftdriver into an isolated temp cache dir before timing starts,
+ * so downloadChromedriver()'s "exact version already present" check (see
+ * driverManager.ts's `downloadChromedriver`) short-circuits and no network
+ * call happens during either measured path — only the PATH probe +
+ * version-detect overhead this step is meant to save is being timed, not
+ * download variance.
+ *
+ * Run with:  npm run bench -- driver-resolution
+ */
+import { describe, it } from 'vitest';
+import { resolveChromeDriver } from '../../src/lib/driverManager.js';
+import path from 'path';
+import os from 'os';
+import fs from 'fs';
+import { median, sample, printTable } from './_perf-utils.js';
+
+const WARMUP_ITERATIONS = 1;
+const MEASURED_ITERATIONS = 5;
+
+const DRIVER_ENV_VARS = [
+  'CRAFTDRIVER_CHROMEDRIVER_PATH',
+  'CRAFTDRIVER_GECKODRIVER_PATH',
+  'CRAFTDRIVER_DRIVER_PATH',
+  'CRAFTDRIVER_CACHE_DIR',
+  'CRAFTDRIVER_OFFLINE',
+  'CHROMEDRIVER_PATH',
+  'SE_CHROMEDRIVER',
+  'CRAFTDRIVER_SKIP_PATH_PROBE',
+  'CHROMEWEBDRIVER',
+];
+
+function unsetEnvVars(keys: string[]): () => void {
+  const saved: Record<string, string | undefined> = {};
+  for (const key of keys) {
+    saved[key] = process.env[key];
+    delete process.env[key];
+  }
+  return () => {
+    for (const key of keys) {
+      if (saved[key] === undefined) delete process.env[key];
+      else process.env[key] = saved[key];
+    }
+  };
+}
+
+describe('Driver resolution: CI-provided directory vs PATH-probe/version-detect fallback', () => {
+  it(
+    'resolveChromeDriver(): CHROMEWEBDRIVER vs cold PATH-probe/version-detect fallback',
+    async () => {
+      const testRoot = path.join(os.tmpdir(), `craftdriver-perf-driverres-${process.pid}`);
+      const testCacheDir = path.join(testRoot, 'cache');
+      fs.rmSync(testRoot, { recursive: true, force: true });
+      const restoreEnv = unsetEnvVars(DRIVER_ENV_VARS);
+
+      try {
+        process.env.CRAFTDRIVER_CACHE_DIR = testCacheDir;
+
+        // Pre-populate the isolated cache with the already-downloaded driver
+        // from this machine's real cache, keyed under its detected version, so
+        // downloadChromedriver()'s exact-version check hits and no network
+        // call happens in either measured path below.
+        const realCacheDir = path.join(os.homedir(), '.cache', 'craftdriver', 'chromedriver');
+        if (!fs.existsSync(realCacheDir)) {
+          throw new Error(
+            `No pre-existing chromedriver cache at ${realCacheDir}. Run \`npm test\` once first ` +
+            `so this benchmark can measure resolution overhead without a network download.`,
+          );
+        }
+        fs.mkdirSync(testCacheDir, { recursive: true });
+        fs.cpSync(realCacheDir, path.join(testCacheDir, 'chromedriver'), { recursive: true });
+
+        /** Clear only the TTL memo, keeping the pre-copied driver files, so
+         *  resolution falls all the way through PATH probe + version-detect
+         *  every iteration instead of hitting the warm-cache read. */
+        function clearResolutionMemo(): void {
+          fs.rmSync(path.join(testCacheDir, 'metadata.json'), { force: true });
+        }
+
+        async function fallbackOnce(): Promise<number> {
+          clearResolutionMemo();
+          const start = performance.now();
+          await resolveChromeDriver();
+          return performance.now() - start;
+        }
+
+        const fallback = await sample(fallbackOnce, WARMUP_ITERATIONS, MEASURED_ITERATIONS);
+
+        // Now measure the CI-dir fast path: point CHROMEWEBDRIVER at a copy of
+        // the same real driver binary.
+        const binName = os.platform() === 'win32' ? 'chromedriver.exe' : 'chromedriver';
+        const ciDir = path.join(testRoot, 'chromewebdriver');
+        fs.mkdirSync(ciDir, { recursive: true });
+        const versionDir = fs.readdirSync(path.join(testCacheDir, 'chromedriver'))[0];
+        const platformDir = fs.readdirSync(path.join(testCacheDir, 'chromedriver', versionDir))[0];
+        fs.copyFileSync(
+          path.join(testCacheDir, 'chromedriver', versionDir, platformDir, binName),
+          path.join(ciDir, binName),
+        );
+        if (os.platform() !== 'win32') fs.chmodSync(path.join(ciDir, binName), 0o755);
+        process.env.CHROMEWEBDRIVER = ciDir;
+
+        async function ciDirOnce(): Promise<number> {
+          const start = performance.now();
+          await resolveChromeDriver();
+          return performance.now() - start;
+        }
+
+        const ciDetection = await sample(ciDirOnce, WARMUP_ITERATIONS, MEASURED_ITERATIONS);
+
+        printTable('resolveChromeDriver() wall time', [
+          { label: 'CHROMEWEBDRIVER set (new)', values: ciDetection },
+          { label: 'PATH-probe/version-detect (old)', values: fallback },
+        ]);
+        const gap = median(fallback) - median(ciDetection);
+        console.log(
+          `  CI-dir detection saves ~${gap.toFixed(1)}ms per cold resolveChromeDriver() call ` +
+          `vs. the PATH-probe/version-detect fallback.`,
+        );
+      } finally {
+        restoreEnv();
+        fs.rmSync(testRoot, { recursive: true, force: true });
+      }
+    },
+    60_000,
+  );
+});


### PR DESCRIPTION
## Summary

Base is now `main` directly (was stacked on `feat/ci-driver-detection` /
open PR #28; #28 has since been merged and that branch retired, so this PR
now carries its own two commits plus the two that used to live upstream of
it). Four commits:

- **feat: auto-detect CI-provided driver directories (GitHub Actions)** —
  recognizes the runner's own pre-installed, version-matched driver via
  `CHROMEWEBDRIVER` / `GECKOWEBDRIVER`, skipping a blocking PATH-probe +
  Chrome-version-detect spawn on every cold `Browser.launch()`.
- **perf: measure CI-detection savings** — isolates that step in a
  micro-benchmark: ~0ms (an `fs.existsSync` check) vs. ~360ms for the old
  fallback.
- **feat: add browserPath to launch a custom browser binary
  (Chrome/Chromium/Firefox)** — adds `LaunchOptions.browserPath` (plus
  `CRAFTDRIVER_CHROME_PATH`/`CRAFTDRIVER_FIREFOX_PATH`/`CRAFTDRIVER_BROWSER_PATH`/`CHROME_BIN`/`FIREFOX_BIN`/`SE_CHROME_PATH`/`SE_FIREFOX_PATH`
  env vars) so craftdriver can launch a custom Chromium/Firefox build —
  previously it detected the system browser only to pick a chromedriver
  version, never forwarded a binary path to the driver at all. When
  chromedriver has to be auto-downloaded and a `browserPath` was given,
  version detection now reads that binary instead of probing for system
  Chrome. Scoped to Chrome/Chromium/Firefox only — an earlier draft of this
  commit also claimed Electron support, but that was never verified against
  a real Electron binary and the version-detection approach (`--version` on
  the binary) doesn't match how the reference implementations handle
  Electron, so the claim was dropped rather than shipped unverified.
- **test: verify craftdriver launches on macOS and Windows in CI** — adds a
  `cross-platform-smoke` GitHub Actions matrix job (macos-latest,
  windows-latest) that launches Chrome and Firefox and runs a few
  interactions each via `tests/chrome-smoke.test.ts` (twin of the existing
  `tests/firefox-smoke.test.ts`) — real, non-doc-research verification that
  craftdriver works on those OSes, and that the CHROMEWEBDRIVER/GECKOWEBDRIVER
  auto-detection above actually engages there. **Confirmed green on both
  macos-latest and windows-latest.**

## Test plan
- [x] `npm run lint` / `npm run build` / `npm run docs:check` clean
- [x] Full suite green on Chrome (331 passed/2 skipped)
- [x] New `tests/browser-binary-path.test.ts` (10 tests, incl. a real Chrome launch through `browserPath`) and `tests/chrome-smoke.test.ts` pass locally
- [x] `cross-platform-smoke` CI job green on macos-latest and windows-latest
