### PR TITLE
feat(logs): always capture console/error logs; remove captureLogs opt-in

### DIFF
--- a/.github/instructions/tests.instructions.md
+++ b/.github/instructions/tests.instructions.md
@@ -57,11 +57,12 @@ describe('feature name', () => {
 });
 ```
 
-For BiDi-only features, add `enableBiDi: true` and clear state between tests:
+For BiDi-only features, no extra launch option is needed — BiDi is on by
+default. Just clear state between tests:
 
 ```typescript
 beforeAll(async () => {
-  browser = await Browser.launch({ browserName: BROWSER_NAME, enableBiDi: true });
+  browser = await Browser.launch({ browserName: BROWSER_NAME });
 });
 
 afterEach(async () => {

--- a/docs/browser-api.md
+++ b/docs/browser-api.md
@@ -29,7 +29,6 @@ const browser = await Browser.launch({
 |--------|------|---------|-------------|
 | `browserName` | `'chrome' \| 'chromium' \| 'firefox'` | `'chrome'` | Browser to launch |
 | `enableBiDi` | `boolean` | `true` | Use WebDriver BiDi. Set `false` only when running against a browser that does not support it — every BiDi-only feature then throws a `requires BiDi` error if called. |
-| `captureLogs` | `boolean` | `false` | Start console/error log capture immediately at launch instead of lazily on first `browser.logs`/`onConsole`/`onError`/`waitForConsole` touch. See [Console Logs And JavaScript Errors](./browser-logs.md). |
 | `storageState` | `string` | — | Path to a session-state JSON file to load on startup |
 | `mobileEmulation` | `MobileEmulation \| DeviceName` | — | Mobile device emulation settings (Chrome/Chromium only) |
 | `downloadsDir` | `string` | temp dir | Directory where downloaded files are saved |

--- a/docs/browser-logs.md
+++ b/docs/browser-logs.md
@@ -12,35 +12,20 @@ emitted a known log message.
 
 ## Capture Timing
 
-Capture is lazy by default. CraftDriver subscribes to log events the first time
-you touch `browser.logs.onLog()`, `.onConsole()`, `.onError()`, `.on()`,
-`.waitForConsole()`, or `.waitForError()`.
-
-Messages emitted before that first touch are not captured, so this can return an
-empty array:
+Capture is automatic. CraftDriver subscribes to log events at launch, so
+messages emitted at any point — including during the first navigation, before you
+ever touch `browser.logs` — are captured. There is nothing to enable and no
+listener to pre-arm:
 
 ```typescript
 await browser.navigateTo('https://example.com');
-const messages = browser.logs.getMessages();
-```
-
-Start capture before the action that logs:
-
-```typescript
-const warning = browser.logs.waitForConsole((msg) => msg.level === 'warn');
-
 await browser.getByRole('button', { name: 'Show warning' }).click();
-expect((await warning).text).toContain('Heads up');
+const messages = browser.logs.getMessages(); // includes the warning
 ```
 
-Or start capture immediately at launch:
-
-```typescript
-const browser = await Browser.launch({
-  browserName: 'chrome',
-  captureLogs: true,
-});
-```
+The subscription rides the connect-time batch, so it costs no extra round trip
+and no measurable overhead. Use `clearLogs()` if you want to assert only on
+messages emitted after a certain point.
 
 ## Read Collected Messages
 

--- a/docs/recipes/console-error-gate.md
+++ b/docs/recipes/console-error-gate.md
@@ -8,7 +8,7 @@ uses the live
 [console errors example](https://dtopuzov.github.io/craftdriver/examples/console-errors.html).
 
 ```ts
-const browser = await Browser.launch({ browserName: 'chrome' });
+const browser = await Browser.launch();
 
 await browser.navigateTo('https://dtopuzov.github.io/craftdriver/examples/console-errors.html');
 browser.logs.clearLogs();

--- a/docs/recipes/console-error-gate.md
+++ b/docs/recipes/console-error-gate.md
@@ -1,17 +1,14 @@
 # Fail On Console And JavaScript Errors
 
 A flow can look correct in the DOM while quietly throwing in the console — a
-failed fetch, an undefined access, a rejected promise. Capture logs at launch,
-run the flow, then assert no JavaScript errors were reported so those failures
-break the test instead of reaching users. This recipe uses the live
+failed fetch, an undefined access, a rejected promise. Logs are captured
+automatically from launch, so you can run the flow and then assert no JavaScript
+errors were reported, breaking the test instead of reaching users. This recipe
+uses the live
 [console errors example](https://dtopuzov.github.io/craftdriver/examples/console-errors.html).
-It enables `captureLogs` at launch, so it shows the `launch` call.
 
 ```ts
-const browser = await Browser.launch({
-  browserName: 'chrome',
-  captureLogs: true,
-});
+const browser = await Browser.launch({ browserName: 'chrome' });
 
 await browser.navigateTo('https://dtopuzov.github.io/craftdriver/examples/console-errors.html');
 browser.logs.clearLogs();
@@ -38,7 +35,7 @@ await logged;
 
 ## Notes
 
-- `assertNoErrors()` checks captured JavaScript errors, so keep `captureLogs: true`.
+- `assertNoErrors()` checks captured JavaScript errors — capture is automatic, nothing to enable.
 - Call `clearLogs()` before the flow so errors from earlier tests don't bleed in.
 - Use `waitForConsole()` / `waitForError()` when a specific message is the thing you're asserting.
 

--- a/docs/recipes/file-upload-download.md
+++ b/docs/recipes/file-upload-download.md
@@ -10,10 +10,7 @@ then downloads a report from the
 It sets `downloadsDir` at launch, so it shows the `launch` call.
 
 ```ts
-const browser = await Browser.launch({
-  browserName: 'chrome',
-  downloadsDir: '.tmp/downloads',
-});
+const browser = await Browser.launch({ downloadsDir: '.tmp/downloads' });
 
 await browser.navigateTo('https://dtopuzov.github.io/craftdriver/examples/upload.html');
 await browser.find('#file-input').setInputFiles('tests/fixtures/sample.txt');

--- a/docs/recipes/login-once-reuse-session.md
+++ b/docs/recipes/login-once-reuse-session.md
@@ -15,7 +15,7 @@ Run this once as a setup step. It is one of the few recipes that shows
 ```ts
 import { Browser } from 'craftdriver';
 
-const browser = await Browser.launch({ browserName: 'chrome' });
+const browser = await Browser.launch();
 
 await browser.navigateTo('https://dtopuzov.github.io/craftdriver/examples/login.html');
 await browser.getByLabel('Username').fill('alice');
@@ -32,10 +32,7 @@ await browser.quit();
 Launch with `storageState` and the browser starts already signed in.
 
 ```ts
-const browser = await Browser.launch({
-  browserName: 'chrome',
-  storageState: '.auth/alice.json',
-});
+const browser = await Browser.launch({ storageState: '.auth/alice.json' });
 
 await browser.navigateTo('https://dtopuzov.github.io/craftdriver/examples/login.html');
 await browser.expect('#welcome').toContainText('Welcome back, alice!');

--- a/docs/recipes/mobile-flow-with-network-and-logs.md
+++ b/docs/recipes/mobile-flow-with-network-and-logs.md
@@ -9,10 +9,7 @@ Because mobile emulation is a launch-time capability, this recipe shows the
 `launch` call.
 
 ```ts
-const browser = await Browser.launch({
-  browserName: 'chrome', // mobile emulation is Chrome/Chromium only
-  mobileEmulation: 'Pixel 7',
-});
+const browser = await Browser.launch({ mobileEmulation: 'Pixel 7' });
 
 // ?bidi=true makes the demo page issue real requests for interception.
 await browser.navigateTo('https://dtopuzov.github.io/craftdriver/examples/network.html?bidi=true');

--- a/docs/recipes/mobile-flow-with-network-and-logs.md
+++ b/docs/recipes/mobile-flow-with-network-and-logs.md
@@ -12,7 +12,6 @@ Because mobile emulation is a launch-time capability, this recipe shows the
 const browser = await Browser.launch({
   browserName: 'chrome', // mobile emulation is Chrome/Chromium only
   mobileEmulation: 'Pixel 7',
-  captureLogs: true,
 });
 
 // ?bidi=true makes the demo page issue real requests for interception.
@@ -33,7 +32,7 @@ browser.logs.assertNoErrors();
 
 - Mobile emulation is currently Chrome/Chromium only.
 - Mock before the action if the page reads data during that step.
-- Keep `captureLogs: true` so `assertNoErrors()` has something to check.
+- Console/error capture is automatic, so `assertNoErrors()` always has the full picture.
 
 ## Learn More
 

--- a/docs/recipes/vitest-browser-lifecycle.md
+++ b/docs/recipes/vitest-browser-lifecycle.md
@@ -18,7 +18,6 @@ describe('login page', () => {
   beforeAll(async () => {
     browser = await Browser.launch({
       browserName: 'chrome',
-      captureLogs: true,
     });
   });
 

--- a/docs/recipes/vitest-browser-lifecycle.md
+++ b/docs/recipes/vitest-browser-lifecycle.md
@@ -16,9 +16,7 @@ describe('login page', () => {
   let browser: Browser;
 
   beforeAll(async () => {
-    browser = await Browser.launch({
-      browserName: 'chrome',
-    });
+    browser = await Browser.launch();
   });
 
   beforeEach(async () => {

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -14,7 +14,7 @@ process crash cannot lose the evidence that led up to it.
 ```ts
 import { chromium } from 'craftdriver';
 
-const browser = await chromium.launch({ enableBiDi: true });
+const browser = await chromium.launch();
 
 await browser.startTrace({ outDir: './artefacts/login' });
 try {
@@ -202,7 +202,7 @@ import { autoTrace } from './auto-trace';
 
 describe('Login', () => {
   let browser: Browser;
-  beforeAll(async () => { browser = await Browser.launch({ enableBiDi: true }); });
+  beforeAll(async () => { browser = await Browser.launch(); });
   afterAll(async () => { await browser.quit(); });
 
   autoTrace(() => browser);   // ← that's it

--- a/skills/craftdriver/SKILL.md
+++ b/skills/craftdriver/SKILL.md
@@ -34,8 +34,9 @@ break the moment markup shifts.
 3. `instanceof CraftdriverError` is true on every public throw;
    `instanceof Error` is also true.
 4. BiDi features (`network`, `logs`, tracing, init scripts, true load
-   events) require `Browser.launch({ enableBiDi: true })`. The error
-   code on the wrong transport is `UNSUPPORTED`.
+   events) work out of the box — `enableBiDi` defaults to `true`. They only
+   break if you explicitly pass `enableBiDi: false`; the error code on the
+   wrong transport is `UNSUPPORTED`.
 5. Tests fetch from the example server. Start it in a separate
    terminal: `npm run examples:start` before `npm test`.
 

--- a/skills/craftdriver/cheatsheet.md
+++ b/skills/craftdriver/cheatsheet.md
@@ -12,7 +12,8 @@ import { Browser } from 'craftdriver';
 const browser = await Browser.launch({
   browserName: 'chrome',   // 'chrome' | 'chromium' | 'firefox'
   headless: true,
-  enableBiDi: true,        // required for network / logs / tracing / init scripts
+  // enableBiDi defaults to true — network / logs / tracing / init scripts
+  // all need it, so only set enableBiDi: false if you must disable it.
 });
 try {
   await browser.navigateTo('https://example.com');

--- a/skills/craftdriver/patterns.md
+++ b/skills/craftdriver/patterns.md
@@ -6,7 +6,7 @@ Worked recipes. Each is ≤ ~200 tokens; load on demand from
 ## 1. Login, save storage state for reuse
 
 ```ts
-const browser = await Browser.launch({ enableBiDi: true });
+const browser = await Browser.launch();
 await browser.navigateTo('https://app.example.com/login');
 await browser.locator(By.labelText('Email')).fill('jane@example.com');
 await browser.locator(By.labelText('Password')).fill(process.env.PW!);
@@ -23,10 +23,7 @@ await browser.quit();
 
 ```ts
 const state = JSON.parse(await fs.readFile('.auth/state.json', 'utf8'));
-const browser = await Browser.launch({
-  enableBiDi: true,
-  storageState: state,
-});
+const browser = await Browser.launch({ storageState: state });
 await browser.navigateTo('https://app.example.com/dashboard');
 await browser.locator(By.testId('dashboard')).expect().toBeVisible();
 ```

--- a/src/lib/bidi/index.ts
+++ b/src/lib/bidi/index.ts
@@ -56,11 +56,10 @@ export class BiDiSession {
    *
    * Fetches the initial context tree and arms every event subscription every
    * session needs unconditionally in a single parallel batch (one `getTree`,
-   * one `session.subscribe` covering context-lifecycle + network events —
-   * down from the previous six serial round trips). `log.entryAdded` is
-   * intentionally NOT subscribed here — log capture stays lazy, armed on
-   * first `browser.logs`/`onConsole`/`onError`/`on()` access (see
-   * `LogMonitor`).
+   * one `session.subscribe` covering context-lifecycle + network + log events —
+   * down from the previous six serial round trips). `log.entryAdded` rides this
+   * same batch, so console/error capture is always armed at launch at zero extra
+   * round trips — no opt-in, no lazy first-touch race.
    *
    * Network subscription is bundled into this same batch (not deferred)
    * because it's provably race-free here — `waitForRequest`/`waitForResponse`
@@ -96,6 +95,10 @@ export class BiDiSession {
         'network.responseCompleted',
         'network.fetchError',
         'network.authRequired',
+        // Console/error capture is always on. Folded in here so it costs no
+        // extra round trip and is armed before connect() resolves — it can't
+        // race a fast launch→quit (measured free; see docs/browser-logs.md).
+        'log.entryAdded',
       ]),
     ]);
 
@@ -110,9 +113,12 @@ export class BiDiSession {
     this._network = new NetworkInterceptor(this.connection, this.context);
     this._network.markSubscribed();
 
-    // Logs stay lazy: no construction, no subscribe. `get logs()` below
-    // constructs `LogMonitor` on first access; its own `.initialize()` fires
-    // on the first `onLog`/`onConsole`/`onError`/`on()` registration.
+    // Logs: `log.entryAdded` was subscribed in the batch above, so construct
+    // the monitor pre-marked as subscribed and wire its handler now (a
+    // same-tick no-op subscribe) — capture is live before connect() resolves.
+    this._logs = new LogMonitor(this.connection, this.context);
+    this._logs.markSubscribed();
+    await this._logs.initialize();
 
     opts?.onContextTree?.(contexts);
 
@@ -148,7 +154,11 @@ export class BiDiSession {
    */
   get logs(): LogMonitor {
     if (!this._logs) {
+      // Defensive: connect() always constructs + arms the monitor, so this
+      // only runs if BiDi came up through some other path. Self-arm here so
+      // capture works without the caller pre-arming a listener.
       this._logs = new LogMonitor(this.connection, this.context);
+      void this._logs.initialize();
     }
     return this._logs;
   }

--- a/src/lib/bidi/logs.ts
+++ b/src/lib/bidi/logs.ts
@@ -43,6 +43,7 @@ export type ErrorHandler = (error: JavaScriptError) => void;
 export class LogMonitor {
   private connection: BiDiConnection;
   private subscribed = false;
+  private handlersWired = false;
   private context?: BrowsingContext;
 
   private allHandlers = new Set<LogHandler>();
@@ -59,21 +60,37 @@ export class LogMonitor {
   }
 
   /**
-   * Initialize log event subscriptions
+   * Mark the `log.entryAdded` subscription as already armed — used when
+   * `BiDiSession.connect()` folds it into the merged connect-time batch so a
+   * later `initialize()` skips the redundant `session.subscribe` and only
+   * wires the event handler. Mirrors `NetworkInterceptor.markSubscribed()`.
+   */
+  markSubscribed(): void {
+    this.subscribed = true;
+  }
+
+  /**
+   * Wire the `log.entryAdded` handler. Normally called once from
+   * `BiDiSession.connect()` after `markSubscribed()`, so the subscribe step is
+   * a same-tick no-op; the subscribe branch only runs for the defensive
+   * `get logs()` fallback that constructs a monitor outside connect().
    */
   async initialize(): Promise<void> {
-    if (this.subscribed) return;
+    if (this.handlersWired) return;
 
-    await this.connection.subscribe(
-      ['log.entryAdded'],
-      this.context ? [this.context] : undefined
-    );
+    if (!this.subscribed) {
+      await this.connection.subscribe(
+        ['log.entryAdded'],
+        this.context ? [this.context] : undefined
+      );
+      this.subscribed = true;
+    }
 
     this.connection.on('log.entryAdded', (params) => {
       this.handleLogEntry(params as unknown as LogEntry);
     });
 
-    this.subscribed = true;
+    this.handlersWired = true;
   }
 
   /**
@@ -81,7 +98,6 @@ export class LogMonitor {
    */
   onLog(handler: LogHandler): () => void {
     this.allHandlers.add(handler);
-    void this.initialize();
     return () => this.allHandlers.delete(handler);
   }
 
@@ -90,7 +106,6 @@ export class LogMonitor {
    */
   onConsole(handler: ConsoleHandler): () => void {
     this.consoleHandlers.add(handler);
-    void this.initialize();
     return () => this.consoleHandlers.delete(handler);
   }
 
@@ -99,7 +114,6 @@ export class LogMonitor {
    */
   onError(handler: ErrorHandler): () => void {
     this.errorHandlers.add(handler);
-    void this.initialize();
     return () => this.errorHandlers.delete(handler);
   }
 
@@ -111,7 +125,6 @@ export class LogMonitor {
       this.levelHandlers.set(level, new Set());
     }
     this.levelHandlers.get(level)!.add(handler);
-    void this.initialize();
     return () => this.levelHandlers.get(level)?.delete(handler);
   }
 

--- a/src/lib/browser.ts
+++ b/src/lib/browser.ts
@@ -144,15 +144,6 @@ export interface LaunchOptions {
    * throws a `requires BiDi (enableBiDi: true)` error if called).
    */
   enableBiDi?: boolean;
-  /**
-   * Start console/error log capture immediately at launch instead of lazily
-   * on first `browser.logs`/`onConsole`/`onError`/`waitForConsole` access.
-   * **Defaults to `false`** — log capture is lazy by default so sessions that
-   * never touch `browser.logs` don't pay its subscription cost. Set `true` if
-   * you need to guarantee capture of console/error output emitted between
-   * `Browser.launch()` and your first `browser.logs` touch.
-   */
-  captureLogs?: boolean;
   /** Load session state from file on launch. BiDi is always used when this is set. */
   storageState?: string;
   /** Enable mobile device emulation (Chrome/Chromium only) */
@@ -538,10 +529,6 @@ export class Browser {
     const wsUrl = (driver as any).__wsUrl;
     if (wsUrl && options.enableBiDi !== false) {
       await browser.initBiDi(wsUrl);
-      if (options.captureLogs && browser.bidiSession?.isConnected()) {
-        // Arm log capture now instead of lazily on first browser.logs touch.
-        void browser.bidiSession.logs.initialize();
-      }
     }
 
     // Load session state if provided

--- a/tests/_auto-trace.ts
+++ b/tests/_auto-trace.ts
@@ -6,7 +6,7 @@
  * Usage:
  *   describe('my feature', () => {
  *     let browser: Browser;
- *     beforeAll(async () => { browser = await Browser.launch({ enableBiDi: true }); });
+ *     beforeAll(async () => { browser = await Browser.launch(); });
  *     afterAll(async () => { await browser.quit(); });
  *     autoTrace(() => browser);   // ← one line
  *     // ... tests

--- a/tests/error-codes.test.ts
+++ b/tests/error-codes.test.ts
@@ -17,7 +17,7 @@ describe('error codes', () => {
   let browser: Browser;
 
   beforeAll(async () => {
-    browser = await Browser.launch({ browserName: BROWSER_NAME, enableBiDi: true });
+    browser = await Browser.launch({ browserName: BROWSER_NAME });
     browser.setDefaultTimeout(500);
   });
 

--- a/tests/logs.test.ts
+++ b/tests/logs.test.ts
@@ -7,10 +7,7 @@ describe('Console Logs and JavaScript Errors', () => {
   const baseUrl = EXAMPLES_BASE_URL;
 
   beforeAll(async () => {
-    browser = await Browser.launch({
-      browserName: BROWSER_NAME,
-      enableBiDi: true,
-    });
+    browser = await Browser.launch({ browserName: BROWSER_NAME });
   });
 
   beforeEach(async () => {

--- a/tests/network.test.ts
+++ b/tests/network.test.ts
@@ -9,10 +9,7 @@ describe('Network Mocking and Interception', () => {
   const networkPageUrl = `${baseUrl}/network.html?bidi=true`;
 
   beforeAll(async () => {
-    browser = await Browser.launch({
-      browserName: BROWSER_NAME,
-      enableBiDi: true,
-    });
+    browser = await Browser.launch({ browserName: BROWSER_NAME });
   });
 
   afterEach(async () => {

--- a/tests/recipes/console-error-gate.test.ts
+++ b/tests/recipes/console-error-gate.test.ts
@@ -13,7 +13,6 @@ describe('fail on console and JavaScript errors', () => {
   beforeAll(async () => {
     browser = await Browser.launch({
       browserName: BROWSER_NAME,
-      captureLogs: true,
     });
   });
 

--- a/tests/recipes/mobile-flow-with-network-and-logs.test.ts
+++ b/tests/recipes/mobile-flow-with-network-and-logs.test.ts
@@ -13,7 +13,6 @@ describe('mobile flow with a mocked backend and log gate', () => {
     browser = await Browser.launch({
       browserName: 'chrome', // mobile emulation is Chrome/Chromium only
       mobileEmulation: 'Pixel 7',
-      captureLogs: true,
     });
   });
 

--- a/tests/recipes/vitest-browser-lifecycle.test.ts
+++ b/tests/recipes/vitest-browser-lifecycle.test.ts
@@ -11,7 +11,6 @@ describe('login page', () => {
   beforeAll(async () => {
     browser = await Browser.launch({
       browserName: BROWSER_NAME,
-      captureLogs: true,
     });
   });
 

--- a/tests/tracing.test.ts
+++ b/tests/tracing.test.ts
@@ -30,7 +30,7 @@ describe('Tracing', () => {
   const baseUrl = EXAMPLES_BASE_URL;
 
   beforeAll(async () => {
-    browser = await Browser.launch({ browserName: BROWSER_NAME, enableBiDi: true });
+    browser = await Browser.launch({ browserName: BROWSER_NAME });
   });
 
   afterAll(async () => {

--- a/tests/wait-for-network.test.ts
+++ b/tests/wait-for-network.test.ts
@@ -26,7 +26,7 @@ describe('waitForRequest and waitForResponse', () => {
   }
 
   beforeAll(async () => {
-    browser = await Browser.launch({ browserName: BROWSER_NAME, enableBiDi: true });
+    browser = await Browser.launch({ browserName: BROWSER_NAME });
     await browser.navigateTo(networkPageUrl);
   });
 


### PR DESCRIPTION
## What this PR does

Console/error log capture is now **automatic and unconditional**. `browser.logs` just works — read results whenever you like, in any order, with nothing to enable:

```ts
const b = await Browser.launch();
await b.navigateTo(url);
await b.click('#btn-console-error');
b.logs.getLogsByLevel('error');   // captured — no setup, no pre-armed listener
```

`log.entryAdded` rides the existing connect-time batch subscribe, so capture is armed before `launch()` returns. No opt-in, no lazy first-touch race.

## Is it performance, behavior, or a bug fix?

**A behavior/DX change, plus a bug fix, and it removes API surface. Performance-neutral (measured).**

- **Behavior / DX (main change):** logs are always captured. The previous lazy default silently dropped anything logged before your first `browser.logs` touch (BiDi `log.entryAdded` is forward-only) — that footgun is gone.
- **API removal (breaking, by choice):** the `captureLogs` launch option is **removed**, along with the lazy first-touch arming path. It shipped as opt-in in 1.1.1; capture is now the default, so the option is redundant. We measured the "sessions that never read logs" case the opt-out was meant to protect and it was **+0.6%** (noise), so there was no reason to keep it. **`Browser.launch({ captureLogs: true })` no longer type-checks.** Given v1 is days old, we're shipping this in a **minor** on purpose — a major bump this soon would surprise users more than removing a two-day-old opt-in flag.
- **Bug fix:** the old `captureLogs: true` path used fire-and-forget `void logs.initialize()`; a fast `launch → quit` outran the in-flight subscribe and threw an **unhandled `Error: Connection closed`** (12 in a 12-launch bench). The subscribe is folded into the awaited `connect()` batch now — **0 after**, race-free.
- **Performance:** not a speedup — the goal was to prove making capture unconditional is free. It is (rides the existing batch subscribe, no extra round trip).

### Evidence (`craftdriver-perf` → `bench:logs-default`)

Within-run eager-vs-lazy (the valid comparison — run-to-run machine drift was ~10%):

| Axis | eager vs lazy |
|---|---|
| startup | **+0.3%** |
| chatty page, 800 logs, never read | **+0.6%** |

Both sub-1%, deep in noise.

## Changes

- `src/lib/bidi/index.ts` — `log.entryAdded` folded unconditionally into the batch subscribe; `LogMonitor` constructed + wired eagerly in `connect()`; `captureLogs` connect option removed.
- `src/lib/bidi/logs.ts` — dropped the redundant `void this.initialize()` lazy-arming from `onLog`/`onConsole`/`onError`/`on` (capture is armed at connect); `get logs()` fallback self-arms defensively.
- `src/lib/browser.ts` — `captureLogs` option + all plumbing removed.
- Docs: `browser-api.md`, `browser-logs.md`, and 3 recipes updated — capture is automatic, opt-out language gone.
- Recipe tests updated to launch without `captureLogs` (proof it's no longer needed).

### Second pass: drop other redundant default-value launch params

While in this code, cleaned up a related smell: several tests/recipes/skill-docs explicitly
wrote `enableBiDi: true` (already the default since day one — nothing to do with this PR's
change) as if it were required or opt-in. That's the same footgun shape as `captureLogs` was:
a default dressed up as something you must ask for.

- Removed `enableBiDi: true` from every test and recipe launch call, and corrected the
  contributor test-writing guide (`.github/instructions/tests.instructions.md`) and the
  bundled agent skill docs (`skills/craftdriver/{SKILL,cheatsheet,patterns}.md`), all of
  which incorrectly implied the flag needs to be set.
- Left `enableBiDi: true` alone everywhere it's load-bearing: `tests/perf/*.perf.ts` A/B
  comparison labels (deliberately contrasting true vs false), the
  `requires BiDi (enableBiDi: true)` error-hint strings in `src/lib/browser.ts`, and doc
  prose already correctly annotated "(the default)".
- Simplified recipes to `Browser.launch()` with no params, or only the option the recipe is
  actually about (`downloadsDir` / `storageState` / `mobileEmulation`), dropping the redundant
  `browserName: 'chrome'`. Tests keep `browserName: BROWSER_NAME` since that's a parametrized
  CI-matrix value, not a hardcoded default.

## Verification

- `tests/logs.test.ts` — **20/20**.
- Recipe suite (`npm run test:recipes`) — **18/18**, including `console-error-gate` whose `assertNoErrors()` now works with a plain `Browser.launch()`.
- Edited main tests (error-codes, logs, network, tracing, wait-for-network) — **50/50**.
- `npm run docs:api:check` — clean.
- Manual: default launch captures a read-**after**-click error; fast launch→quit leaks no rejection.

## Compatibility

Removes `captureLogs` from `LaunchOptions` (breaking for the handful who set it in 1.1.1 — it was a two-day-old opt-in). Behavior for everyone else is strictly better: logs that were silently dropped are now captured. Shipping in a minor by maintainer choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
